### PR TITLE
Fix #4317: Fix Enzyme Test file in exclude_times_test.js and migrate it to use @testing-library/react

### DIFF
--- a/test/exclude_times_test.test.js
+++ b/test/exclude_times_test.test.js
@@ -1,12 +1,13 @@
 import React from "react";
-import { mount } from "enzyme";
+import { render } from "@testing-library/react";
 import { setTime, newDate } from "../src/date_utils";
 import DatePicker from "../src/index.jsx";
 
 describe("DatePicker", () => {
   it("should disable times specified in excludeTimes props", () => {
-    var now = newDate();
-    var datePicker = mount(
+    const now = newDate();
+
+    const { container: datePicker } = render(
       <DatePicker
         open
         showTimeSelect
@@ -18,8 +19,10 @@ describe("DatePicker", () => {
         ]}
       />,
     );
-    expect(
-      datePicker.find(".react-datepicker__time-list-item--disabled"),
-    ).toHaveLength(4);
+
+    const disabledTimeItems = datePicker.querySelectorAll(
+      ".react-datepicker__time-list-item--disabled",
+    );
+    expect(disabledTimeItems.length).toBe(4);
   });
 });

--- a/test/exclude_times_test.test.js
+++ b/test/exclude_times_test.test.js
@@ -8,17 +8,18 @@ describe("DatePicker", () => {
     var now = newDate();
     var datePicker = mount(
       <DatePicker
+        open
         showTimeSelect
         excludeTimes={[
-          setTime(now, { hours: 17, minutes: 0 }),
-          setTime(now, { hours: 18, minutes: 30 }),
-          setTime(now, { hours: 19, minutes: 30 }),
-          setTime(now, { hours: 17, minutes: 30 }),
+          setTime(now, { hour: 17, minute: 0 }),
+          setTime(now, { hour: 18, minute: 30 }),
+          setTime(now, { hour: 19, minute: 30 }),
+          setTime(now, { hour: 17, minute: 30 }),
         ]}
       />,
     );
     expect(
       datePicker.find(".react-datepicker__time-list-item--disabled"),
-    ).not.toBeNull();
+    ).toHaveLength(4);
   });
 });


### PR DESCRIPTION
Closes #4317

### Summary
This PR addresses the issues in the test file `exclude_times_test.js` and also migrated the test cases to use `@testing-library/react` instead of `enzyme` as requested by @martijnrusschen

### Changes Made

- Fix the `setTime` call
- Open the `<DatePicker />` component to test it, by passing the `open` prop
- Use `.toHaveLength(4)` instead of using `.not.toBeNull`
- Migrated the file to use `@testing-library/react`