### PR TITLE
Fix #4170: Clear the previously selected date on empty input with showTimeSelectOnly

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -542,21 +542,14 @@ export default class DatePicker extends React.Component {
     if (
       this.props.showTimeSelectOnly &&
       this.props.selected &&
+      date &&
       !isSameDay(date, this.props.selected)
     ) {
-      if (date == null) {
-        date = set(this.props.selected, {
-          hours: getHours(this.props.selected),
-          minutes: getMinutes(this.props.selected),
-          seconds: getSeconds(this.props.selected),
-        });
-      } else {
-        date = set(this.props.selected, {
-          hours: getHours(date),
-          minutes: getMinutes(date),
-          seconds: getSeconds(date),
-        });
-      }
+      date = set(this.props.selected, {
+        hours: getHours(date),
+        minutes: getMinutes(date),
+        seconds: getSeconds(date),
+      });
     }
     if (date || !event.target.value) {
       this.setSelected(date, event, true);

--- a/test/datepicker_test.test.js
+++ b/test/datepicker_test.test.js
@@ -4,6 +4,7 @@ import { findDOMNode } from "react-dom";
 import TestUtils from "react-dom/test-utils";
 import { enUS, enGB } from "date-fns/locale";
 import { mount } from "enzyme";
+import { render, fireEvent } from "@testing-library/react";
 import defer from "lodash/defer";
 import DatePicker, { registerLocale } from "../src/index.jsx";
 import Day from "../src/day.jsx";
@@ -2100,6 +2101,55 @@ describe("DatePicker", () => {
       expect(utils.getHours(date)).toBe(8);
       expect(utils.getMinutes(date)).toBe(22);
     });
+  });
+
+  it("clears the selected date on empty date input", () => {
+    let date = "2023-10-23 10:00:00";
+    const selected = utils.newDate(date);
+
+    const { container: datepicker } = render(
+      <DatePicker
+        selected={selected}
+        onChange={(d) => {
+          date = d;
+        }}
+        showTimeSelect
+        dateFormat="MMMM d, yyyy h:mm aa"
+      />,
+    );
+
+    const input = datepicker.querySelector(
+      ".react-datepicker__input-container > input",
+    );
+    fireEvent.change(input, { target: { value: "" } });
+
+    expect(date).toBe(null);
+  });
+
+  it("clears the selected date on empty date input with showTimeSelectOnly", () => {
+    const format = "h:mm aa";
+
+    let date = "2022-02-24 10:00:00";
+    const selected = utils.newDate(date);
+
+    const { container: datepicker } = render(
+      <DatePicker
+        selected={selected}
+        onChange={(d) => {
+          date = d;
+        }}
+        showTimeSelectOnly
+        dateFormat={format}
+        timeFormat={format}
+      />,
+    );
+
+    const input = datepicker.querySelector(
+      ".react-datepicker__input-container > input",
+    );
+    fireEvent.change(input, { target: { value: "" } });
+
+    expect(date).toBe(null);
   });
 
   it("should selected month when specified minDate same month", () => {


### PR DESCRIPTION
Closes #4170

### Summary
This PR addresses an issue where the DatePicker was not clearing the previously selected time when the user deletes the value in the date input via keyboard.  This issue was only coming when the `showTimeSelectOnly` is enabled.

### Changes Made:

- I updated the new date value only if the value exist, else set the null value, instead of restoring back to the previously selected value
- I added test cases to validate the above case both with and without `showTimeSelectOnly` using React Test Library