### PR TITLE
Fix #4482: Update Month Picker and Year Picker to select dates also on press of "SPACE" key

### DIFF
--- a/src/date_utils.js
+++ b/src/date_utils.js
@@ -917,3 +917,8 @@ export function isDateBefore(date, dateToCompare) {
 
   return isBefore(midnightDate, midnightDateToCompare);
 }
+
+export function isSpaceKeyDown(event) {
+  const SPACE_KEY = " ";
+  return event.key === SPACE_KEY;
+}

--- a/src/month.jsx
+++ b/src/month.jsx
@@ -669,8 +669,7 @@ export default class Month extends React.Component {
               this.onMonthClick(ev, m);
             }}
             onKeyDown={(ev) => {
-              const SPACE_KEY = " ";
-              if (ev.key === SPACE_KEY) {
+              if (utils.isSpaceKeyDown(ev)) {
                 ev.preventDefault();
                 ev.key = "Enter";
               }

--- a/src/month.jsx
+++ b/src/month.jsx
@@ -669,6 +669,12 @@ export default class Month extends React.Component {
               this.onMonthClick(ev, m);
             }}
             onKeyDown={(ev) => {
+              const SPACE_KEY = " ";
+              if (ev.key === SPACE_KEY) {
+                ev.preventDefault();
+                ev.key = "Enter";
+              }
+
               this.onMonthKeyDown(ev, m);
             }}
             onMouseEnter={() => this.onMonthMouseEnter(m)}

--- a/src/year.jsx
+++ b/src/year.jsx
@@ -245,6 +245,12 @@ export default class Year extends React.Component {
             this.onYearClick(ev, y);
           }}
           onKeyDown={(ev) => {
+            const SPACE_KEY = " ";
+            if (ev.key === SPACE_KEY) {
+              ev.preventDefault();
+              ev.key = "Enter";
+            }
+
             this.onYearKeyDown(ev, y);
           }}
           tabIndex={this.getYearTabIndex(y)}

--- a/src/year.jsx
+++ b/src/year.jsx
@@ -245,8 +245,7 @@ export default class Year extends React.Component {
             this.onYearClick(ev, y);
           }}
           onKeyDown={(ev) => {
-            const SPACE_KEY = " ";
-            if (ev.key === SPACE_KEY) {
+            if (utils.isSpaceKeyDown(ev)) {
               ev.preventDefault();
               ev.key = "Enter";
             }

--- a/test/month_test.test.js
+++ b/test/month_test.test.js
@@ -1509,6 +1509,38 @@ describe("Month", () => {
       );
     });
 
+    it("should select March when Space is pressed", () => {
+      const SPACE_KEY = " ";
+      let preSelected = false;
+      let selectedDate = null;
+      const setPreSelection = () => {
+        preSelected = true;
+      };
+      const setSelectedDate = (param) => {
+        selectedDate = param;
+      };
+
+      const monthComponent = renderMonth({
+        selected: utils.newDate("2015-02-01"),
+        day: utils.newDate("2015-02-01"),
+        setPreSelection: setPreSelection,
+        preSelection: utils.newDate("2015-02-01"),
+        onDayClick: setSelectedDate,
+      });
+
+      monthComponent
+        .find(".react-datepicker__month-1")
+        .simulate("keydown", getKey("ArrowLeft"));
+      monthComponent
+        .find(".react-datepicker__month-2")
+        .simulate("keydown", getKey(SPACE_KEY));
+
+      expect(preSelected).toBe(true);
+      expect(selectedDate.toString()).toBe(
+        utils.newDate("2015-03-01").toString(),
+      );
+    });
+
     it("should prevent navigation to disabled month", () => {
       let preSelected = utils.newDate("2015-08-01");
       const setPreSelection = (param) => {

--- a/test/year_picker_test.test.js
+++ b/test/year_picker_test.test.js
@@ -599,7 +599,7 @@ describe("YearPicker", () => {
       expect(utils.getYear(selectedDay)).toBe(2021);
     });
 
-    it("should select 2021 when Enter key is pressed", () => {
+    it("should select 2021 when Space key is pressed", () => {
       const yearPicker = getPicker("2021-01-01");
 
       const target = TestUtils.findRenderedDOMComponentWithClass(

--- a/test/year_picker_test.test.js
+++ b/test/year_picker_test.test.js
@@ -6,6 +6,7 @@ import TestUtils from "react-dom/test-utils";
 import ReactDOM from "react-dom";
 import * as utils from "../src/date_utils.js";
 import Calendar from "../src/calendar.jsx";
+import { getKey } from "./test_utils.js";
 
 describe("YearPicker", () => {
   it("should show year picker component when showYearPicker prop is present", () => {
@@ -597,6 +598,20 @@ describe("YearPicker", () => {
       TestUtils.Simulate.keyDown(target, { key: "Enter", code: 13, which: 13 });
       expect(utils.getYear(selectedDay)).toBe(2021);
     });
+
+    it("should select 2021 when Enter key is pressed", () => {
+      const yearPicker = getPicker("2021-01-01");
+
+      const target = TestUtils.findRenderedDOMComponentWithClass(
+        yearPicker,
+        "react-datepicker__year-text--selected",
+      );
+
+      const SPACE_KEY = " ";
+      TestUtils.Simulate.keyDown(target, getKey(SPACE_KEY));
+      expect(utils.getYear(selectedDay)).toBe(2021);
+    });
+
     it("should disable keyboard navigation", () => {
       const yearPicker = getPicker("2021-01-01", {
         disabledKeyboardNavigation: true,


### PR DESCRIPTION
Closes #4482

## Description
This PR addresses the date selection behavior in the calendar component to enhance accessibility based on W3C WAI-ARIA principles.  Previously, the "Enter" key alone is used to select a Month picker and a Year Picker.   But As per W3C WAI-ARIA principle both the "Enter" & "Space" keys should be able to select a date.  Currently, only the date selector is selecting a date on both the "Enter" and the "Space" key.  Hence I updated the Year Picker and the Month Picker to work like the date picker to select a date both by "Space" and "Enter" keys click.

[Reference Link](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/examples/datepicker-dialog/#:~:text=Select%20the%20date%2C%20close%20the%20dialog%2C%20and%20move%20focus%20to%20the%20%22Choose%20Date%22%20button.)

## Changes Made
- Updated Year picker and Month picker to select values also on a click of the "Space" key in a similar way we handled on the date picker
- Updated the corresponding test cases.