### PR TITLE
Fix #4521: ♻️ Update ariaLabel format in month.jsx to display the selected month and year in "Month MMMM, yyyy"

### DIFF
--- a/src/month.jsx
+++ b/src/month.jsx
@@ -759,14 +759,19 @@ export default class Month extends React.Component {
       showMonthYearPicker,
       showQuarterYearPicker,
       day,
-      ariaLabelPrefix = "month ",
+      ariaLabelPrefix = "Month ",
     } = this.props;
+
+    const formattedAriaLabelPrefix = ariaLabelPrefix
+      ? ariaLabelPrefix.trim() + " "
+      : "";
+
     return (
       <div
         className={this.getClassNames()}
         onMouseLeave={!this.props.usePointerEvent ? this.handleMouseLeave : undefined}
         onPointerLeave={this.props.usePointerEvent ? this.handleMouseLeave : undefined}
-        aria-label={`${ariaLabelPrefix} ${utils.formatDate(day, "yyyy-MM")}`}
+        aria-label={`${formattedAriaLabelPrefix}${utils.formatDate(day, "MMMM, yyyy")}`}
         role="listbox"
       >
         {showMonthYearPicker

--- a/test/month_test.test.js
+++ b/test/month_test.test.js
@@ -38,15 +38,54 @@ describe("Month", () => {
   });
 
   it("should have the month aria-label", () => {
-    const dateString = "2015-12";
+    const date = utils.newDate("2015-12-01");
+
+    const month = TestUtils.renderIntoDocument(<Month day={date} />);
+    const month_dom = TestUtils.findRenderedDOMComponentWithClass(
+      month,
+      "react-datepicker__month",
+    );
+
+    const expectedAriaLabel = utils.formatDate(date, "MMMM, yyyy");
+    expect(month_dom.getAttribute("aria-label")).toContain(expectedAriaLabel);
+  });
+
+  it("should have the month aria-label with the specified prefix", () => {
+    const date = utils.newDate("2015-12-01");
+    const ariaLabelPrefix = "Selected Month";
+
     const month = TestUtils.renderIntoDocument(
-      <Month day={utils.newDate(`${dateString}-01`)} />,
+      <Month day={date} ariaLabelPrefix={ariaLabelPrefix} />,
     );
     const month_dom = TestUtils.findRenderedDOMComponentWithClass(
       month,
       "react-datepicker__month",
     );
-    expect(month_dom.getAttribute("aria-label")).toContain(dateString);
+
+    const expectedAriaLabel =
+      `${ariaLabelPrefix} ${utils.formatDate(date, "MMMM, yyyy")}`.toLowerCase();
+    expect(month_dom.getAttribute("aria-label").toLowerCase()).toEqual(
+      expectedAriaLabel,
+    );
+  });
+
+  it("should have the month aria-label without any prefix when ariaLabelPrefix is null", () => {
+    const date = utils.newDate("2015-12-01");
+    const ariaLabelPrefix = null;
+
+    const month = TestUtils.renderIntoDocument(
+      <Month day={date} ariaLabelPrefix={ariaLabelPrefix} />,
+    );
+    const month_dom = TestUtils.findRenderedDOMComponentWithClass(
+      month,
+      "react-datepicker__month",
+    );
+
+    const expectedAriaLabel =
+      `${utils.formatDate(date, "MMMM, yyyy")}`.toLowerCase();
+    expect(month_dom.getAttribute("aria-label").toLowerCase()).toEqual(
+      expectedAriaLabel,
+    );
   });
 
   it("should have an aria-label containing the provided prefix", () => {


### PR DESCRIPTION
Closes #4521

**Description**
This PR enhances the month.jsx component to display the selected month and year in the format `Month December, 2024` instead of the previous format `month 2024-12`.  This change improves the clarity and readability of the selected date for screen reader users.

**Changes Made:**
- Adjested the `aria-label` for accessibility to reflect the new date format
- Change the default ariaLabelPrefix from `month` to `Month`
- Remove the unnecessary spaces after the `ariaLabelPrefix` while using it in `aria-label`

**Testing:**
- Updated the existing test cases to check for the new `aria-label` format
- Added two new test cases to test how the component is handling the custom `ariaLabelPrefix` and a null `ariaLabelPrefix` values