### PR TITLE
Fix #4623: Add dynamic Calendar Aria Labels for selection clarity

### DIFF
--- a/src/calendar.jsx
+++ b/src/calendar.jsx
@@ -1101,6 +1101,8 @@ export default class Calendar extends React.Component {
           className={classnames("react-datepicker", this.props.className, {
             "react-datepicker--time-only": this.props.showTimeSelectOnly,
           })}
+          showTime={this.props.showTimeSelect || this.props.showTimeInput}
+          showTimeSelectOnly={this.props.showTimeSelectOnly}
         >
           {this.renderAriaLiveRegion()}
           {this.renderPreviousButton()}

--- a/src/calendar.jsx
+++ b/src/calendar.jsx
@@ -36,6 +36,8 @@ import {
   yearDisabledAfter,
   yearsDisabledAfter,
   yearsDisabledBefore,
+  quarterDisabledBefore,
+  quarterDisabledAfter,
   getEffectiveMinDate,
   getEffectiveMaxDate,
   addZero,
@@ -491,6 +493,12 @@ export default class Calendar extends React.Component {
       case this.props.showYearPicker:
         allPrevDaysDisabled = yearsDisabledBefore(this.state.date, this.props);
         break;
+      case this.props.showQuarterYearPicker:
+        allPrevDaysDisabled = quarterDisabledBefore(
+          this.state.date,
+          this.props,
+        );
+        break;
       default:
         allPrevDaysDisabled = monthDisabledBefore(this.state.date, this.props);
         break;
@@ -587,6 +595,9 @@ export default class Calendar extends React.Component {
         break;
       case this.props.showYearPicker:
         allNextDaysDisabled = yearsDisabledAfter(this.state.date, this.props);
+        break;
+      case this.props.showQuarterYearPicker:
+        allNextDaysDisabled = quarterDisabledAfter(this.state.date, this.props);
         break;
       default:
         allNextDaysDisabled = monthDisabledAfter(this.state.date, this.props);

--- a/src/calendar_container.jsx
+++ b/src/calendar_container.jsx
@@ -1,12 +1,21 @@
 import PropTypes from "prop-types";
 import React from "react";
 
-export default function CalendarContainer({ className, children }) {
+export default function CalendarContainer({
+  showTimeSelectOnly = false,
+  showTime = false,
+  className,
+  children,
+}) {
+  let ariaLabel = showTimeSelectOnly
+    ? "Choose Time"
+    : `Choose Date${showTime ? " and Time" : ""}`;
+
   return (
     <div
       className={className}
       role="dialog"
-      aria-label="Choose Date"
+      aria-label={ariaLabel}
       aria-modal="true"
     >
       {children}
@@ -15,6 +24,8 @@ export default function CalendarContainer({ className, children }) {
 }
 
 CalendarContainer.propTypes = {
+  showTimeSelectOnly: PropTypes.bool,
+  showTime: PropTypes.bool,
   className: PropTypes.string,
   children: PropTypes.node,
 };

--- a/src/date_utils.js
+++ b/src/date_utils.js
@@ -34,6 +34,7 @@ import { max } from "date-fns/max";
 import { differenceInCalendarDays } from "date-fns/differenceInCalendarDays";
 import { differenceInCalendarMonths } from "date-fns/differenceInCalendarMonths";
 import { differenceInCalendarYears } from "date-fns/differenceInCalendarYears";
+import { differenceInCalendarQuarters } from "date-fns/differenceInCalendarQuarters";
 import { startOfDay } from "date-fns/startOfDay";
 import { startOfWeek } from "date-fns/startOfWeek";
 import { startOfMonth } from "date-fns/startOfMonth";
@@ -649,6 +650,36 @@ export function monthDisabledAfter(day, { maxDate, includeDates } = {}) {
     (includeDates &&
       includeDates.every(
         (includeDate) => differenceInCalendarMonths(nextMonth, includeDate) > 0,
+      )) ||
+    false
+  );
+}
+
+export function quarterDisabledBefore(day, { minDate, includeDates } = {}) {
+  const firstDayOfYear = startOfYear(day);
+  const previousQuarter = subQuarters(firstDayOfYear, 1);
+
+  return (
+    (minDate && differenceInCalendarQuarters(minDate, previousQuarter) > 0) ||
+    (includeDates &&
+      includeDates.every(
+        (includeDate) =>
+          differenceInCalendarQuarters(includeDate, previousQuarter) > 0,
+      )) ||
+    false
+  );
+}
+
+export function quarterDisabledAfter(day, { maxDate, includeDates } = {}) {
+  const lastDayOfYear = endOfYear(day);
+  const nextQuarter = addQuarters(lastDayOfYear, 1);
+
+  return (
+    (maxDate && differenceInCalendarQuarters(nextQuarter, maxDate) > 0) ||
+    (includeDates &&
+      includeDates.every(
+        (includeDate) =>
+          differenceInCalendarQuarters(nextQuarter, includeDate) > 0,
       )) ||
     false
   );

--- a/test/calendar_test.test.js
+++ b/test/calendar_test.test.js
@@ -9,7 +9,7 @@ import DatePicker from "../src/index.jsx";
 import * as utils from "../src/date_utils";
 import { eo } from "date-fns/locale/eo";
 import { fi } from "date-fns/locale/fi";
-import { isSunday } from "date-fns";
+import { endOfYear, isSunday, startOfMonth } from "date-fns";
 import { getKey } from "./test_utils";
 
 // TODO Possibly rename
@@ -1821,6 +1821,27 @@ describe("Calendar", () => {
         increaseYear();
       });
       expect(utils.getYear(instance.state.date)).toBe(1994);
+    });
+
+    it("should hide the previous year navigation arrow button when the minDate falls under the currently visible year ", () => {
+      const { container } = render(
+        <Calendar showQuarterYearPicker minDate={startOfMonth(new Date())} />,
+      );
+      const previous = container.querySelector(
+        ".react-datepicker__navigation--previous",
+      );
+      expect(previous).toBeNull();
+    });
+
+    it("should hide the next year navigation arrow button when the maxDate falls under the currently visible year ", () => {
+      const { container } = render(
+        <Calendar showQuarterYearPicker maxDate={endOfYear(new Date())} />,
+      );
+
+      const next = container.querySelector(
+        ".react-datepicker__navigation--next",
+      );
+      expect(next).toBeNull();
     });
   });
 

--- a/test/calendar_test.test.js
+++ b/test/calendar_test.test.js
@@ -2145,7 +2145,7 @@ describe("Calendar", () => {
   });
 
   describe("calendar container", () => {
-    it("should work", () => {
+    it("should render Calendar with accessibility props", () => {
       const { container } = render(
         <Calendar
           dateFormat={dateFormat}
@@ -2159,6 +2159,42 @@ describe("Calendar", () => {
       expect(dialog.getAttribute("role")).toBe("dialog");
       expect(dialog.getAttribute("aria-modal")).toBe("true");
       expect(dialog.getAttribute("aria-label")).toBe("Choose Date");
+    });
+
+    it("should display corresponding aria-label for Calendar with showTimeSelect", () => {
+      const { container } = render(
+        <Calendar dateFormat={dateFormat} showTimeSelect />,
+      );
+
+      const dialog = container.querySelector(".react-datepicker");
+      expect(dialog).not.toBeNull();
+      expect(dialog.getAttribute("aria-label").toLowerCase().trim()).toBe(
+        "choose date and time",
+      );
+    });
+
+    it("should display corresponding aria-label for Calendar with showTimeInput", () => {
+      const { container } = render(
+        <Calendar dateFormat={dateFormat} showTimeInput />,
+      );
+
+      const dialog = container.querySelector(".react-datepicker");
+      expect(dialog).not.toBeNull();
+      expect(dialog.getAttribute("aria-label").toLowerCase().trim()).toBe(
+        "choose date and time",
+      );
+    });
+
+    it("should display corresponding aria-label for Calendar with showTimeSelectOnly", () => {
+      const { container } = render(
+        <Calendar dateFormat={dateFormat} showTimeSelectOnly />,
+      );
+
+      const dialog = container.querySelector(".react-datepicker");
+      expect(dialog).not.toBeNull();
+      expect(dialog.getAttribute("aria-label").toLowerCase().trim()).toBe(
+        "choose time",
+      );
     });
   });
 });


### PR DESCRIPTION
Closes #4623

### Description
This PR updates the Calendar component to display dynamic aria-label based on the selection purpose (date/date and time/time only).  After this change the `aria-label` will be

- "Choose Date and Time" if either we pass `showTimeInput` or `showTimeSelect`.
- "Choose Time" if we pass `showTimeSelectOnly`.
- "Choose Date" in all the other cases.

### Changes Made
- Updated aria-label to reflect selection options like `showTimeInput` or `showTimeSelect` or `showTimeSelectOnly`.
- Added test cases for validation.