### PR TITLE
Fix #4011: 🐛 Handle Arrow Navigation on calendar days even when the minDate/maxDate is null

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -760,8 +760,8 @@ export default class DatePicker extends Component<
 
   // When checking preSelection via min/maxDate, times need to be manipulated via getStartOfDay/getEndOfDay
   setPreSelection = (date?: Date | null): void => {
-    const hasMinDate = this.props.minDate !== undefined;
-    const hasMaxDate = this.props.maxDate !== undefined;
+    const hasMinDate = isDate(this.props.minDate);
+    const hasMaxDate = isDate(this.props.maxDate);
     let isValidDateSelection = true;
     if (date) {
       const dateStartOfDay = getStartOfDay(date);

--- a/test/datepicker_test.test.js
+++ b/test/datepicker_test.test.js
@@ -1055,6 +1055,45 @@ describe("DatePicker", () => {
     ).toBe(utils.formatDate(data.copyM, data.testFormat));
   });
 
+  it("should handle onDayKeyDown when the minDate is null", () => {
+    const data = getOnInputKeyDownStuff({ minDate: null });
+    fireEvent.keyDown(data.dateInput, getKey("ArrowDown"));
+    fireEvent.keyDown(getSelectedDayNode(data.instance), getKey("ArrowLeft"));
+
+    data.copyM = utils.subDays(data.copyM, 1);
+    expect(
+      utils.formatDate(data.instance.state.preSelection, data.testFormat),
+    ).toBe(utils.formatDate(data.copyM, data.testFormat));
+  });
+
+  it("should handle onDayKeyDown when the maxDate is null", () => {
+    const data = getOnInputKeyDownStuff({ minDate: null });
+    fireEvent.keyDown(data.dateInput, getKey("ArrowDown"));
+    fireEvent.keyDown(getSelectedDayNode(data.instance), getKey("ArrowRight"));
+
+    data.copyM = utils.addDays(data.copyM, 1);
+    expect(
+      utils.formatDate(data.instance.state.preSelection, data.testFormat),
+    ).toBe(utils.formatDate(data.copyM, data.testFormat));
+  });
+
+  it("should handle onDayKeyDown when both the minDate and the maxDate is null", () => {
+    const data = getOnInputKeyDownStuff({ minDate: null });
+    fireEvent.keyDown(data.dateInput, getKey("ArrowDown"));
+
+    fireEvent.keyDown(getSelectedDayNode(data.instance), getKey("ArrowLeft"));
+    data.copyM = utils.subDays(data.copyM, 1);
+    expect(
+      utils.formatDate(data.instance.state.preSelection, data.testFormat),
+    ).toBe(utils.formatDate(data.copyM, data.testFormat));
+
+    fireEvent.keyDown(getSelectedDayNode(data.instance), getKey("ArrowRight"));
+    data.copyM = utils.addDays(data.copyM, 1);
+    expect(
+      utils.formatDate(data.instance.state.preSelection, data.testFormat),
+    ).toBe(utils.formatDate(data.copyM, data.testFormat));
+  });
+
   // excluded stuff
   it("should skip over excluded date when ArrowRight is pressed", () => {
     const date = new Date("2024-05-01");


### PR DESCRIPTION
Closes #4011

## Description
As mentioned in the Linked issue when the minDate or the maxDate is set to null, the mouse navigations are allowed for all the days and months, but however the keyboard navigation is disabled.  That means when the minDate/maxDate is null, eventhough users are allowed to select any dates, but just they can't do it via keyboard arrows.  I resolved this issue in this PR and added a corresponding test cases to verify the changes

## Contribution checklist
- [x] I have followed the [contributing guidelines](https://github.com/Hacker0x01/react-datepicker/blob/main/CONTRIBUTING.md).
- [x] I have added sufficient test coverage for my changes.
- [x] I have formatted my code with Prettier and checked for linting issues with ESLint for code readability.
