### PR TITLE
Fix #4934: ✅ Fix the test case failing issue

### DIFF
--- a/src/test/datepicker_test.test.tsx
+++ b/src/test/datepicker_test.test.tsx
@@ -462,7 +462,10 @@ describe("DatePicker", () => {
   });
 
   it("should update the preSelection state when a day is selected with Enter press", () => {
-    const data = getOnInputKeyDownStuff({ shouldCloseOnSelect: false });
+    const data = getOnInputKeyDownStuff({
+      shouldCloseOnSelect: false,
+      selected: "2024-06-06",
+    });
 
     fireEvent.keyDown(data.dateInput, getKey(KeyType.ArrowDown));
     const selectedDayNode = getSelectedDayNode(data.container);
@@ -1039,8 +1042,9 @@ describe("DatePicker", () => {
     expect(document.body.querySelector("#portal-id-dom-test")).not.toBeNull();
   });
 
-  function getOnInputKeyDownStuff(opts = {}) {
-    const m = newDate();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  function getOnInputKeyDownStuff(opts: { [key: string]: any } = {}) {
+    const m = newDate(opts.selected);
     const copyM = newDate(m);
     const testFormat = "yyyy-MM-dd";
     const exactishFormat = "yyyy-MM-dd hh: zzzz";


### PR DESCRIPTION
Closes #4934

Pass the default date to the getOnInputKeyDownStuff to avoid switching to the next month view when the current date is in the last row of the current month
- Apply this fix as the render fails to rerender days to the next month view

## Contribution checklist
- [x] I have followed the [contributing guidelines](https://github.com/Hacker0x01/react-datepicker/blob/main/CONTRIBUTING.md).
- [x] I have added sufficient test coverage for my changes.
- [x] I have formatted my code with Prettier and checked for linting issues with ESLint for code readability.
