### PR TITLE
Fix #5010, 🐛 Restrict the focus to the disabled months/quarter/year using the initial Tab key navigation

### DIFF
--- a/src/month.tsx
+++ b/src/month.tsx
@@ -847,9 +847,8 @@ export default class Month extends Component<MonthProps> {
       this.isMonthDisabledForLabelDate(preSelectedMonth);
 
     const tabIndex =
-      !this.props.disabledKeyboardNavigation &&
       m === preSelectedMonth &&
-      !isPreSelectedMonthDisabled
+      !(isPreSelectedMonthDisabled || this.props.disabledKeyboardNavigation)
         ? "0"
         : "-1";
 
@@ -867,9 +866,8 @@ export default class Month extends Component<MonthProps> {
     );
 
     const tabIndex =
-      !this.props.disabledKeyboardNavigation &&
       q === preSelectedQuarter &&
-      !isCurrentQuarterDisabled
+      !(isCurrentQuarterDisabled || this.props.disabledKeyboardNavigation)
         ? "0"
         : "-1";
 

--- a/src/month.tsx
+++ b/src/month.tsx
@@ -843,8 +843,13 @@ export default class Month extends Component<MonthProps> {
       return "-1";
     }
     const preSelectedMonth = getMonth(this.props.preSelection);
+    const { isDisabled: isPreSelectedMonthDisabled } =
+      this.isMonthDisabledForLabelDate(preSelectedMonth);
+
     const tabIndex =
-      !this.props.disabledKeyboardNavigation && m === preSelectedMonth
+      !this.props.disabledKeyboardNavigation &&
+      m === preSelectedMonth &&
+      !isPreSelectedMonthDisabled
         ? "0"
         : "-1";
 
@@ -856,8 +861,15 @@ export default class Month extends Component<MonthProps> {
       return "-1";
     }
     const preSelectedQuarter = getQuarter(this.props.preSelection);
+    const isCurrentQuarterDisabled = isQuarterDisabled(
+      this.props.day,
+      this.props,
+    );
+
     const tabIndex =
-      !this.props.disabledKeyboardNavigation && q === preSelectedQuarter
+      !this.props.disabledKeyboardNavigation &&
+      q === preSelectedQuarter &&
+      !isCurrentQuarterDisabled
         ? "0"
         : "-1";
 

--- a/src/test/month_test.test.tsx
+++ b/src/test/month_test.test.tsx
@@ -28,7 +28,7 @@ import {
 import Month from "../month";
 
 import { runAxe } from "./run_axe";
-import { getKey, range } from "./test_utils";
+import { getKey, range, openDateInput, gotoNextView } from "./test_utils";
 
 import type { RenderResult } from "@testing-library/react";
 
@@ -2523,6 +2523,87 @@ describe("Month", () => {
           ".react-datepicker__quarter-text--keyboard-selected",
         ),
       ).toBeNull();
+    });
+  });
+
+  describe("Auto-Focus", () => {
+    it("should auto-focus on the same selected month when navigating to the next/previous year", () => {
+      const date = newDate("2024-06-01");
+      const selectedMonth = date.getMonth();
+
+      const { container } = render(
+        <DatePicker selected={date} showMonthYearPicker />,
+      );
+
+      openDateInput(container);
+      gotoNextView(container);
+
+      const preSelectedDateElement = container.querySelector(
+        `.react-datepicker__month-text.react-datepicker__month-${selectedMonth}`,
+      )!;
+      expect(preSelectedDateElement.getAttribute("tabindex")).toBe("0");
+    });
+
+    it("shouldn't auto-focus on the same selected month when navigating to the next/previous year if the corresponding month is disabled", () => {
+      const date = newDate("2024-06-01");
+      const selectedMonth = date.getMonth();
+      const excludeDate = newDate(`2025-0${selectedMonth + 1}-01`);
+
+      const { container } = render(
+        <DatePicker
+          selected={date}
+          showMonthYearPicker
+          excludeDates={[excludeDate]}
+        />,
+      );
+
+      openDateInput(container);
+      gotoNextView(container);
+
+      const preSelectedDateElement = container.querySelector(
+        `.react-datepicker__month-text.react-datepicker__month-${selectedMonth}`,
+      )!;
+      expect(preSelectedDateElement.getAttribute("tabindex")).toBe("-1");
+    });
+
+    it("should auto-focus on the same selected quarter when navigating to the next/previous year", () => {
+      const date = newDate("2024-06-01");
+
+      const { container } = render(
+        <DatePicker selected={date} showQuarterYearPicker />,
+      );
+
+      openDateInput(container);
+      const selectedQuarterValue = getQuarter(date);
+      gotoNextView(container);
+
+      const preSelectedDateElement = container.querySelector(
+        `.react-datepicker__quarter-text.react-datepicker__quarter-${selectedQuarterValue}`,
+      )!;
+      expect(preSelectedDateElement.getAttribute("tabindex")).toBe("0");
+    });
+
+    it("shouldn't auto-focus on the same selected quarter when navigating to the next/previous year if the corresponding quarter date is disabled", () => {
+      const date = newDate("2024-06-01");
+      const selectedMonth = date.getMonth();
+      const excludeDate = newDate(`2025-0${selectedMonth + 1}-01`);
+
+      const { container } = render(
+        <DatePicker
+          selected={date}
+          showQuarterYearPicker
+          excludeDates={[excludeDate]}
+        />,
+      );
+
+      openDateInput(container);
+      const selectedQuarterValue = getQuarter(date);
+      gotoNextView(container);
+
+      const preSelectedDateElement = container.querySelector(
+        `.react-datepicker__quarter-text.react-datepicker__quarter-${selectedQuarterValue}`,
+      )!;
+      expect(preSelectedDateElement.getAttribute("tabindex")).toBe("-1");
     });
   });
 });

--- a/src/test/test_utils.ts
+++ b/src/test/test_utils.ts
@@ -1,3 +1,5 @@
+import { fireEvent } from "@testing-library/react";
+
 import { KeyType } from "../date_utils";
 
 interface KeyEvent {
@@ -64,4 +66,17 @@ export const range = (from: number, to: number): number[] => {
     list.push(i);
   }
   return list;
+};
+
+export const openDateInput = (container: Element) => {
+  const dateInput = container.querySelector("input")!;
+  fireEvent.focus(dateInput);
+};
+
+export const gotoNextView = (container: Element) => {
+  const calendar = container.querySelector(".react-datepicker")!;
+  const nextButton = calendar.querySelector(
+    ".react-datepicker__navigation--next",
+  )!;
+  fireEvent.click(nextButton);
 };

--- a/src/year.tsx
+++ b/src/year.tsx
@@ -402,8 +402,9 @@ export default class Year extends Component<YearProps> {
       return "-1";
     }
     const preSelected = getYear(this.props.preSelection);
+    const isPreSelectedYearDisabled = isYearDisabled(y, this.props);
 
-    return y === preSelected ? "0" : "-1";
+    return y === preSelected && !isPreSelectedYearDisabled ? "0" : "-1";
   };
 
   getYearContainerClassNames = () => {


### PR DESCRIPTION
Closes #5010

## Description
As I elaborate the issue in the above mentioned link, the disabled dates are able to be focused when the initial focus happens on the calendar component.  As a fix, I blocked the focus to be applied for the disabled dates.

## Contribution checklist
- [x] I have followed the [contributing guidelines](https://github.com/Hacker0x01/react-datepicker/blob/main/CONTRIBUTING.md).
- [x] I have added sufficient test coverage for my changes.
- [x] I have formatted my code with Prettier and checked for linting issues with ESLint for code readability.
