### PR TITLE
🧪 test-fix: Update the test case to use the random month except the current month

### DIFF
--- a/src/test/calendar_test.test.tsx
+++ b/src/test/calendar_test.test.tsx
@@ -36,6 +36,7 @@ import DatePicker from "../index";
 
 import {
   getKey,
+  getRandomMonthExcludingCurrent,
   SafeElementWrapper,
   safeQuerySelector,
   safeQuerySelectorAll,
@@ -1287,11 +1288,10 @@ describe("Calendar", () => {
         .safeQuerySelector("select")
         .getElement();
 
+      const month = getRandomMonthExcludingCurrent();
       fireEvent.change(select, {
         target: {
-          value: Array.from<HTMLOptionElement>(
-            select.querySelectorAll("option"),
-          ).at(-2)?.value,
+          value: month,
         },
       });
 

--- a/src/test/test_utils.ts
+++ b/src/test/test_utils.ts
@@ -68,6 +68,17 @@ export const range = (from: number, to: number): number[] => {
   return list;
 };
 
+export const getRandomMonthExcludingCurrent = (): number => {
+  const currentMonth = new Date().getMonth();
+
+  let randomMonth;
+  do {
+    randomMonth = Math.floor(Math.random() * 12);
+  } while (randomMonth === currentMonth);
+
+  return randomMonth;
+};
+
 export const openDateInput = (container: Element) => {
   const dateInput = container.querySelector("input")!;
   fireEvent.focus(dateInput);


### PR DESCRIPTION
Closes #5206

## Description
As I described in the issue, currently the test cases are failing as in one of the test cases we try to select the month which is same as the current month.  I fixed it by generating a random month other than the current month.  This is just a test case update.

## Screenshots
![image](https://github.com/user-attachments/assets/4511520c-2bc0-4120-b311-cb6ba75c387c)

## Contribution checklist
- [x] I have followed the [contributing guidelines](https://github.com/Hacker0x01/react-datepicker/blob/main/CONTRIBUTING.md).
- [x] I have added sufficient test coverage for my changes.
- [x] I have formatted my code with Prettier and checked for linting issues with ESLint for code readability.
