### PR TITLE
🧪 Fix the test case failing issue by setting the selected date to be same as the configured least possible month date

### DIFF
--- a/src/test/calendar_test.test.tsx
+++ b/src/test/calendar_test.test.tsx
@@ -449,12 +449,17 @@ describe("Calendar", () => {
   });
 
   it("should not have previous month button when selecting a date in the second month, when min date is specified", () => {
+    const minDate = new Date("2024-11-06");
+    const maxDate = new Date("2025-01-01");
+    const selectedDate = minDate;
+
     const { container } = render(
       <DatePicker
         inline
         monthsShown={2}
-        minDate={new Date("2024-11-06")}
-        maxDate={new Date("2025-01-01")}
+        selected={selectedDate}
+        minDate={minDate}
+        maxDate={maxDate}
       />,
     );
 


### PR DESCRIPTION
Closes #5252

## Description
As mentioned in the linked ticket, we have an issue with one of the testcases as we didn't configure the `selectedDate`.  As a fix I just added the `selectedDate` same as `minDate`

## Contribution checklist
- [x] I have followed the [contributing guidelines](https://github.com/Hacker0x01/react-datepicker/blob/main/CONTRIBUTING.md).
- [x] I have added sufficient test coverage for my changes.
- [x] I have formatted my code with Prettier and checked for linting issues with ESLint for code readability.
