### PR TITLE
🐛 Fix the Selected Year Picker style when no date is selected

### DIFF
--- a/src/test/year_picker_test.test.tsx
+++ b/src/test/year_picker_test.test.tsx
@@ -148,6 +148,20 @@ describe("YearPicker", () => {
     expect(yearElements.length).toBe(0);
   });
 
+  it("should not has selected class where there is no selectedDates", () => {
+    const { container } = render(
+      <Year
+        date={new Date()}
+        onYearMouseEnter={() => {}}
+        onYearMouseLeave={() => {}}
+      />,
+    );
+    const yearElements = Array.from(
+      container.querySelectorAll(".react-datepicker__year-text--selected"),
+    );
+    expect(yearElements.length).toBe(0);
+  });
+
   it("should have current year class when element of array equal of current year", () => {
     const date = new Date();
     const { container } = render(

--- a/src/year.tsx
+++ b/src/year.tsx
@@ -248,7 +248,7 @@ export default class Year extends Component<YearProps> {
     if (selectsMultiple) {
       return selectedDates?.some((date) => year === getYear(date));
     }
-    return !selected || year === getYear(selected);
+    return !!selected && year === getYear(selected);
   };
 
   onYearClick = (


### PR DESCRIPTION
Closes #5573

## Description
As mentioned in the attached ticket, we're having an issue that the year picker is highlighting all the available years when do date is entered.  In this PR I added a fix for it along with the test cases to validate the fix.

## Contribution checklist
- [x] I have followed the [contributing guidelines](https://github.com/Hacker0x01/react-datepicker/blob/main/CONTRIBUTING.md).
- [x] I have added sufficient test coverage for my changes.
- [x] I have formatted my code with Prettier and checked for linting issues with ESLint for code readability.
