### PR TITLE
🐛 Fix EndDatePicker selection range progress

### DIFF
--- a/src/day.tsx
+++ b/src/day.tsx
@@ -312,7 +312,6 @@ export default class Day extends Component<DayProps> {
     if (
       selectsEnd &&
       startDate &&
-      !endDate &&
       (isAfter(selectingDate, startDate) || isEqual(selectingDate, startDate))
     ) {
       return isDayInRange(day, startDate, selectingDate);

--- a/src/test/datepicker_test.test.tsx
+++ b/src/test/datepicker_test.test.tsx
@@ -3153,35 +3153,6 @@ describe("DatePicker", () => {
         ).toBe(true);
       }
     });
-
-    it("should not apply '--in-selecting-range' class to the days till the date that matched selectedDate in the next months (endDatePicker)", () => {
-      const startDay = 3;
-      const endDay = 8;
-      const startDate = new Date(`2025/02/${startDay}`);
-      const endDate = new Date(`2025/02/${endDay}`);
-
-      const { container } = render(
-        <DatePicker
-          inline
-          selectsEnd
-          startDate={startDate}
-          endDate={endDate}
-          minDate={startDate}
-        />,
-      );
-
-      goToNextMonth(container);
-
-      for (let i = 1; i <= endDay; i++) {
-        const inSelectionRangeDay = safeQuerySelector(
-          container,
-          `.react-datepicker__day--00${i}`,
-        );
-        expect(
-          inSelectionRangeDay.classList.contains(IN_RANGE_DAY_CLASS_NAME),
-        ).toBe(false);
-      }
-    });
   });
 
   describe("selectsRange without inline", () => {


### PR DESCRIPTION
Close #5599

## Description
As mentioned in the linked issue, one of my previous PRs https://github.com/Hacker0x01/react-datepicker/pull/5503 is causing an issue in applying `--in-selecting-range` over the hovered days.

We by default pre-select a selected date on the other months also.  As a result the same date on the other months will be programatically pre-selected (even-though we didn't hover or select) and we use the same state to know the date till we want to highlight.  The same issue also exist for startDate picker also, when navigating to the previous months - as we pre-select the already selected dates for the other months.  So, as a fix I undo my existing fix.

## Contribution checklist
- [x] I have followed the [contributing guidelines](https://github.com/Hacker0x01/react-datepicker/blob/main/CONTRIBUTING.md).
- [x] I have added sufficient test coverage for my changes.
- [x] I have formatted my code with Prettier and checked for linting issues with ESLint for code readability.
