### PR TITLE
docs(examples) 🎨: Fix dayClassName specificity issue

### DIFF
--- a/docs-site/src/components/Examples/style.scss
+++ b/docs-site/src/components/Examples/style.scss
@@ -113,3 +113,16 @@ input {
 .text-success {
   color: green;
 }
+
+.react-datepicker__day {
+  &.highlighted-day {
+    background-color: #ccc;
+    color: #000;
+    border-radius: 0.3rem;
+
+    &:not([aria-disabled="true"]):hover {
+      background-color: #aaa;
+      color: #000;
+    }
+  }
+}

--- a/docs-site/src/examples/ts/customDayClassName.tsx
+++ b/docs-site/src/examples/ts/customDayClassName.tsx
@@ -2,7 +2,7 @@ const CustomDayClassName = () => {
   const [selectedDate, setSelectedDate] = useState<Date | null>(new Date());
 
   const getDayClassName = (date: Date): string => {
-    return date.getDate() === 1 ? "text-success" : "";
+    return date.getDate() === 1 ? "highlighted-day" : "";
   };
 
   return (


### PR DESCRIPTION
**Problem**
This fix is related to a CSS specificity issue in the docsite example "Custom day class name".  In that example even though the `dayClassName` is applied properly, it's not applied in the UI due to CSS Specificity issue.

<img width="1612" height="786" alt="image" src="https://github.com/user-attachments/assets/4b210d03-13d4-4f36-9cd8-2fb2b9b3f712" />


**Changes**
- Increased the specificity of the CSS selector to apply the `dayClassName`  style to the day element
- No functional changes

## Screenshots
<img width="850" height="486" alt="image" src="https://github.com/user-attachments/assets/2503536b-1647-4000-a4e2-ec689ed83427" />


## Contribution checklist
- [x] I have followed the [contributing guidelines](https://github.com/Hacker0x01/react-datepicker/blob/main/CONTRIBUTING.md).
- [x] I have formatted my code with Prettier and checked for linting issues with ESLint for code readability.
