### PR TITLE
✨ Add weekday class support to datepicker days

### DIFF
--- a/src/date_utils.ts
+++ b/src/date_utils.ts
@@ -583,14 +583,14 @@ export function getWeek(date: Date): number {
 }
 
 /**
- * Gets the day of the week code for a given day.
+ * Gets the day-of-the-month code for a given date.
+ * Returns a zero-padded 3-digit string from "001" to "031".
  *
  * @param day - The day.
- * @param locale - The locale.
- * @returns - The day of the week code.
+ * @returns - A string representing the day of the month (e.g. "001", "002", "003", etc).
  */
-export function getDayOfWeekCode(day: Date, locale?: Locale): string {
-  return formatDate(day, "ddd", locale);
+export function getDayOfMonthCode(day: Date): string {
+  return formatDate(day, "ddd");
 }
 
 // *** Start of ***

--- a/src/day.tsx
+++ b/src/day.tsx
@@ -13,7 +13,7 @@ import {
   isEqual,
   isBefore,
   isAfter,
-  getDayOfWeekCode,
+  getDayOfMonthCode,
   getStartOfWeek,
   formatDate,
   type DateFilterOptionsWithDisabled,
@@ -445,7 +445,7 @@ export default class Day extends Component<DayProps> {
     return clsx(
       "react-datepicker__day",
       dayClassName,
-      "react-datepicker__day--" + getDayOfWeekCode(this.props.day),
+      "react-datepicker__day--" + getDayOfMonthCode(this.props.day),
       {
         "react-datepicker__day--disabled": this.isDisabled(),
         "react-datepicker__day--excluded": this.isExcluded(),

--- a/src/day.tsx
+++ b/src/day.tsx
@@ -15,6 +15,7 @@ import {
   isAfter,
   getDayOfMonthCode,
   getStartOfWeek,
+  getWeekdayShortInLocale,
   formatDate,
   type DateFilterOptionsWithDisabled,
   type DateNumberType,
@@ -442,10 +443,13 @@ export default class Day extends Component<DayProps> {
     const dayClassName = this.props.dayClassName
       ? this.props.dayClassName(date)
       : undefined;
+    const baseDayClassName = "react-datepicker__day";
+
     return clsx(
-      "react-datepicker__day",
+      baseDayClassName,
       dayClassName,
-      "react-datepicker__day--" + getDayOfMonthCode(this.props.day),
+      `${baseDayClassName}--${getDayOfMonthCode(this.props.day)}`,
+      `${baseDayClassName}--${getWeekdayShortInLocale(this.props.day).toLowerCase()}`,
       {
         "react-datepicker__day--disabled": this.isDisabled(),
         "react-datepicker__day--excluded": this.isExcluded(),

--- a/src/test/day_test.test.tsx
+++ b/src/test/day_test.test.tsx
@@ -3,7 +3,7 @@ import { es } from "date-fns/locale";
 import React from "react";
 
 import {
-  getDayOfWeekCode,
+  getDayOfMonthCode,
   newDate,
   getDate,
   addDays,
@@ -38,10 +38,10 @@ describe("Day", () => {
       expect(container.textContent).toBe(getDate(day) + "");
     });
 
-    it("should apply the day of week class", () => {
+    it("should apply the day of month class", () => {
       let day = newDate();
       for (let i = 0; i < 7; i++) {
-        const className = "react-datepicker__day--" + getDayOfWeekCode(day);
+        const className = "react-datepicker__day--" + getDayOfMonthCode(day);
         const container = renderDay(day);
         expect(
           container

--- a/src/test/day_test.test.tsx
+++ b/src/test/day_test.test.tsx
@@ -4,6 +4,7 @@ import React from "react";
 
 import {
   getDayOfMonthCode,
+  getWeekdayShortInLocale,
   newDate,
   getDate,
   addDays,
@@ -38,10 +39,26 @@ describe("Day", () => {
       expect(container.textContent).toBe(getDate(day) + "");
     });
 
+    it("should apply the day of week class in default locale (en) ignoring locale provided", () => {
+      let day = newDate();
+      for (let i = 0; i < 7; i++) {
+        const container = renderDay(day, { locale: "pt-BR" });
+        const weekName = getWeekdayShortInLocale(day).toLowerCase();
+        const expectedWeekNameClassName = `react-datepicker__day--${weekName}`;
+
+        expect(
+          container
+            .querySelector(".react-datepicker__day")
+            ?.classList.contains(expectedWeekNameClassName),
+        ).toBe(true);
+        day = addDays(day, 1);
+      }
+    });
+
     it("should apply the day of month class", () => {
       let day = newDate();
       for (let i = 0; i < 7; i++) {
-        const className = "react-datepicker__day--" + getDayOfMonthCode(day);
+        const className = `react-datepicker__day--${getDayOfMonthCode(day)}`;
         const container = renderDay(day);
         expect(
           container


### PR DESCRIPTION
## Description
**Linked issue**: #6217

**Problem**
As mentioned in the attached [issue](https://github.com/Hacker0x01/react-datepicker/issues/6217), we have a problem with an existing feature of adding a week day class to the day component.  Initially we were applying the class based on the weekday short name (E.g. `react-datepicker__day--mon`) as documented in this [PR](https://github.com/Hacker0x01/react-datepicker/pull/800).  However, [when we removed the support of moment js](https://github.com/Hacker0x01/react-datepicker/pull/1527/files), we started applying the class based on the day of month code (E.g. `react-datepicker__day--001`) as we used `ddd` instead of `EEE` in the formatDate function of `getDayOfWeekCode`.  This was updated long back and now many test cases are relying on the month day class names (E.g. `react-datepicker__day--001`). 

In this PR, I reapplied the class based on the weekday short name (E.g. `react-datepicker__day--mon`) as documented in this [PR](https://github.com/Hacker0x01/react-datepicker/pull/800), without removing the month day class names.  I also added a test case to verify that the class is applied correctly.

**Note:** This PR is related to my another [PR](https://github.com/Hacker0x01/react-datepicker/pull/6218), where I updated the function name from getDayOfWeekCode to getDayOfMonthCode to match it's usage in the codebase.

**Changes**
- Reapplied the class based on the weekday short name (E.g. `react-datepicker__day--mon`) as documented in this PR, without removing the month day class names.
- For the class name, I used the existing helper function `getWeekdayShortInLocale` to get the weekday short name in the default locale (en).
- Added a test case to verify that the class is applied correctly.

## Contribution checklist
- [x] I have followed the [contributing guidelines](https://github.com/Hacker0x01/react-datepicker/blob/main/CONTRIBUTING.md).
- [x] I have added sufficient test coverage for my changes.
- [x] I have formatted my code with Prettier and checked for linting issues with ESLint for code readability.