### PR TITLE
Fix #6223 - ♿ Accessibility improvements: Month and Year dropdowns

### DIFF
--- a/src/month_dropdown.tsx
+++ b/src/month_dropdown.tsx
@@ -36,7 +36,12 @@ export default class MonthDropdown extends Component<
   renderSelectOptions = (monthNames: string[]): React.ReactElement[] =>
     monthNames.map<React.ReactElement>(
       (m: string, i: number): React.ReactElement => (
-        <option key={m} value={i}>
+        <option
+          key={m}
+          value={i}
+          aria-label={`Select Month ${m}`}
+          aria-selected={i === this.props.month ? "true" : "false"}
+        >
           {m}
         </option>
       ),
@@ -47,6 +52,7 @@ export default class MonthDropdown extends Component<
       value={this.props.month}
       className="react-datepicker__month-select"
       onChange={(e) => this.onChange(parseInt(e.target.value))}
+      aria-label="Select Month"
     >
       {this.renderSelectOptions(monthNames)}
     </select>
@@ -62,8 +68,14 @@ export default class MonthDropdown extends Component<
       style={{ visibility: visible ? "visible" : "hidden" }}
       className="react-datepicker__month-read-view"
       onClick={this.toggleDropdown}
+      aria-label="Select Month"
+      aria-expanded={this.state.dropdownVisible}
+      aria-haspopup="listbox"
     >
-      <span className="react-datepicker__month-read-view--down-arrow" />
+      <span
+        className="react-datepicker__month-read-view--down-arrow"
+        aria-hidden="true"
+      />
       <span className="react-datepicker__month-read-view--selected-month">
         {monthNames[this.props.month]}
       </span>

--- a/src/month_dropdown_options.tsx
+++ b/src/month_dropdown_options.tsx
@@ -50,6 +50,7 @@ export default class MonthDropdownOptions extends Component<MonthDropdownOptions
             }
           }}
           role="button"
+          aria-label={`Select Month ${month}`}
           tabIndex={0}
           className={
             this.isSelectedMonth(i)

--- a/src/test/month_dropdown_test.test.tsx
+++ b/src/test/month_dropdown_test.test.tsx
@@ -44,6 +44,40 @@ describe("MonthDropdown", () => {
       monthDropdown = getMonthDropdown();
     });
 
+    it("sets proper ARIA on read view button and toggles aria-expanded", () => {
+      const monthReadView = safeQuerySelector(
+        monthDropdown,
+        ".react-datepicker__month-read-view",
+      );
+      expect(monthReadView.getAttribute("aria-label")).toBe("Select Month");
+      expect(monthReadView.getAttribute("aria-haspopup")).toBe("listbox");
+      expect(monthReadView.getAttribute("aria-expanded")).toBe("false");
+
+      fireEvent.click(monthReadView);
+
+      const monthReadViewAfterOpen = safeQuerySelector(
+        monthDropdown,
+        ".react-datepicker__month-read-view",
+      );
+      expect(monthReadViewAfterOpen.getAttribute("aria-expanded")).toBe("true");
+    });
+
+    it("applies aria-label to each month option in scroll dropdown", () => {
+      const monthReadView = safeQuerySelector(
+        monthDropdown,
+        ".react-datepicker__month-read-view",
+      );
+      fireEvent.click(monthReadView);
+
+      const firstOption = safeQuerySelector(
+        monthDropdown,
+        ".react-datepicker__month-option",
+      );
+      expect(firstOption.getAttribute("aria-label")).toBe(
+        "Select Month January",
+      );
+    });
+
     it("shows the selected month in the initial view", () => {
       expect(monthDropdown?.textContent).toContain("December");
     });
@@ -307,6 +341,14 @@ describe("MonthDropdown", () => {
       );
     });
 
+    it("adds aria-label to select element", () => {
+      monthDropdown = getMonthDropdown({ dropdownMode: "select" });
+      const select = monthDropdown.querySelector<HTMLSelectElement>(
+        ".react-datepicker__month-select",
+      );
+      expect(select?.getAttribute("aria-label")).toBe("Select Month");
+    });
+
     it("renders month options with default locale", () => {
       monthDropdown = getMonthDropdown({ dropdownMode: "select" });
       const options = monthDropdown.querySelectorAll("option");
@@ -324,6 +366,24 @@ describe("MonthDropdown", () => {
         "November",
         "December",
       ]);
+    });
+    // Accessibility of options
+    it("adds aria-label and aria-selected to options in select mode", () => {
+      monthDropdown = getMonthDropdown({ dropdownMode: "select", month: 11 });
+      const select = monthDropdown.querySelector<HTMLSelectElement>(
+        ".react-datepicker__month-select",
+      );
+      const options = Array.from(
+        select?.querySelectorAll("option") ?? [],
+      ) as HTMLOptionElement[];
+      expect(options[0]?.getAttribute("aria-label")).toBe(
+        "Select Month January",
+      );
+      expect(options[11]?.getAttribute("aria-label")).toBe(
+        "Select Month December",
+      );
+      expect(options[11]?.getAttribute("aria-selected")).toBe("true");
+      expect(options[0]?.getAttribute("aria-selected")).toBe("false");
     });
     // Short Month Names
     it("renders month options with short name and default locale", () => {

--- a/src/year_dropdown.tsx
+++ b/src/year_dropdown.tsx
@@ -42,7 +42,12 @@ export default class YearDropdown extends Component<
     const options: React.ReactElement[] = [];
     for (let i = minYear; i <= maxYear; i++) {
       options.push(
-        <option key={i} value={i}>
+        <option
+          key={i}
+          value={i}
+          aria-label={`Select Year ${i}`}
+          aria-selected={i === this.props.year ? "true" : "false"}
+        >
           {i}
         </option>,
       );
@@ -59,6 +64,7 @@ export default class YearDropdown extends Component<
       value={this.props.year}
       className="react-datepicker__year-select"
       onChange={this.onSelectChange}
+      aria-label="Select Year"
     >
       {this.renderSelectOptions()}
     </select>
@@ -71,8 +77,14 @@ export default class YearDropdown extends Component<
       style={{ visibility: visible ? "visible" : "hidden" }}
       className="react-datepicker__year-read-view"
       onClick={this.toggleDropdown}
+      aria-label="Select Year"
+      aria-expanded={this.state.dropdownVisible}
+      aria-haspopup="listbox"
     >
-      <span className="react-datepicker__year-read-view--down-arrow" />
+      <span
+        className="react-datepicker__year-read-view--down-arrow"
+        aria-hidden="true"
+      />
       <span className="react-datepicker__year-read-view--selected-year">
         {this.props.year}
       </span>

--- a/src/year_dropdown_options.tsx
+++ b/src/year_dropdown_options.tsx
@@ -136,6 +136,7 @@ export default class YearDropdownOptions extends Component<
         key={year}
         onClick={this.onChange.bind(this, year)}
         onKeyDown={this.handleOptionKeyDown.bind(this, year)}
+        aria-label={`Select Year ${year}`}
         aria-selected={selectedYear === year ? "true" : undefined}
       >
         {selectedYear === year ? (
@@ -156,6 +157,8 @@ export default class YearDropdownOptions extends Component<
           className="react-datepicker__year-option"
           key={"upcoming"}
           onClick={this.incrementYears}
+          role="button"
+          aria-label="Show later years"
         >
           <a className="react-datepicker__navigation react-datepicker__navigation--years react-datepicker__navigation--years-upcoming" />
         </div>,
@@ -168,6 +171,8 @@ export default class YearDropdownOptions extends Component<
           className="react-datepicker__year-option"
           key={"previous"}
           onClick={this.decrementYears}
+          role="button"
+          aria-label="Show earlier years"
         >
           <a className="react-datepicker__navigation react-datepicker__navigation--years react-datepicker__navigation--years-previous" />
         </div>,


### PR DESCRIPTION
## Description
**Linked issue**: #6223

**Problem**
As mentioned in the attached ticket, the month select dropdown (`showMonthDropdown`) and the year select drop down (`showYearDropdown`) lacks ARIA attributes. 

**Changes**
- Added the corresponding aria attributes to the select and the button element to support the dropdown mode (`dropdownMode`) of scroll and select
- Added test cases to validate the change

## Contribution checklist
- [x] I have followed the [contributing guidelines](https://github.com/Hacker0x01/react-datepicker/blob/main/CONTRIBUTING.md).
- [x] I have added sufficient test coverage for my changes.
- [x] I have formatted my code with Prettier and checked for linting issues with ESLint for code readability.
