### PR TITLE
♿️ Fix Calendar auto navigation regex issue for month navigation

### DIFF
--- a/src/date_utils.ts
+++ b/src/date_utils.ts
@@ -359,7 +359,7 @@ export function parseDateForNavigation(
 
   // Try to extract a month (1-12) from the input
   // Look for patterns like "03/", "/03", "03-", "-03" or standalone "03" at start
-  const monthMatch = value.match(/(?:^|[/\-\s])?(0?[1-9]|1[0-2])(?:[/\-\s]|$)/);
+  const monthMatch = value.match(/(?:^|[/\-\s])(0?[1-9]|1[0-2])(?:[/\-\s]|$)/);
   const month =
     monthMatch && monthMatch[1]
       ? parseInt(monthMatch[1], 10) - 1

--- a/src/test/date_utils_test.test.ts
+++ b/src/test/date_utils_test.test.ts
@@ -57,6 +57,7 @@ import {
   isMonthYearDisabled,
   getDefaultLocale,
   safeToDate,
+  parseDateForNavigation,
 } from "../date_utils";
 
 registerLocale("pt-BR", ptBR);
@@ -1855,6 +1856,51 @@ describe("date_utils", () => {
     it("returns null when given an empty string", () => {
       const result = safeToDate("" as unknown as Date);
       expect(result).toBeNull();
+    });
+  });
+
+  describe("parseDateForNavigation", () => {
+    describe("month pattern", () => {
+      it("does not match embedded month digits inside year (e.g., '2003')", () => {
+        const refDate = new Date(1999, 6, 1); // July
+        const result = parseDateForNavigation("2003", refDate)!;
+        expect(result).not.toBeNull();
+        expect(result.getFullYear()).toBe(2003);
+        // Month should fall back to refDate (July) since no valid month token found
+        expect(result.getMonth()).toBe(6);
+      });
+
+      it("extracts month when preceded by start-of-string", () => {
+        const result = parseDateForNavigation("03 2003")!;
+        expect(result.getFullYear()).toBe(2003);
+        expect(result.getMonth()).toBe(2); // March
+      });
+
+      it("extracts month when preceded by delimiters ('/', '-')", () => {
+        const cases = ["03/2003", "03-2003", "/03 2003", "-03 2003"];
+        for (const value of cases) {
+          const result = parseDateForNavigation(value)!;
+          expect(result.getFullYear()).toBe(2003);
+          expect(result.getMonth()).toBe(2); // March
+        }
+      });
+
+      it("does not extract month when not preceded by a boundary (e.g., 'x03y 2003')", () => {
+        const refDate = new Date(1999, 0, 1); // January
+        const result = parseDateForNavigation("x03y 2003", refDate)!;
+        expect(result.getFullYear()).toBe(2003);
+        // Should use refDate month because '03' lacks a valid left boundary
+        expect(result.getMonth()).toBe(0);
+      });
+
+      it("should fallback to the current month on the entered year if no reference date is provided (e.g., '2003')", () => {
+        const result = parseDateForNavigation("2005")!;
+        expect(result).not.toBeNull();
+        expect(result.getFullYear()).toBe(2005);
+
+        const currentMonth = new Date().getMonth();
+        expect(result.getMonth()).toBe(currentMonth);
+      });
     });
   });
 });


### PR DESCRIPTION
## Description
**Linked issue**: #6214

**Problem**
As mentioned in the attached issue, we have an issue with the auto navigation of calendar popup while typing date manually in the date input.  Basically we're navigating to the month  based on the year's last two digit if we didn't provide a month.  E.g.  If we enter `2023` as a date input value, instead of navigating to `Jan 1, 2023`, it's navigating to `March 2023`.  Basically we're taking `March` from 202**3**.  

This issue is because to match the month  we used a regex pattern `/(?:^|[/\-\s])?(0?[1-9]|1[0-2])(?:[/\-\s]|$)/`.  Here the left boundary group was optional (...?), it could match a month inside other digits. Example: in "2003", it matched the trailing "03" since:
**Left:** optional boundary allowed “no boundary”
**Right:** `$` satisfied the end condition

**Changes**
- Require a real left boundary (start or delimiter) so months aren’t matched inside numbers:
- Changed to: `/(?:^|[/\-\s])(0?[1-9]|1[0-2])(?:[/\-\s]|$)/`

It still matches an expected months in inputs like "03/", "/03", "03-", "-03", and standalone "03" at the start.  But no longer matches the “03” embedded in a year like “2003”.

## Contribution checklist
- [x] I have followed the [contributing guidelines](https://github.com/Hacker0x01/react-datepicker/blob/main/CONTRIBUTING.md).
- [x] I have added sufficient test coverage for my changes.
- [x] I have formatted my code with Prettier and checked for linting issues with ESLint for code readability.