### PR TITLE
Improve accessibility for month and year dropdowns (select + custom modes)

### DIFF
--- a/src/month_dropdown.tsx
+++ b/src/month_dropdown.tsx
@@ -62,8 +62,14 @@ export default class MonthDropdown extends Component<
       style={{ visibility: visible ? "visible" : "hidden" }}
       className="react-datepicker__month-read-view"
       onClick={this.toggleDropdown}
+      aria-expanded={this.state.dropdownVisible}
+      aria-haspopup="listbox"
     >
-      <span className="react-datepicker__month-read-view--down-arrow" />
+      <span
+        className="react-datepicker__month-read-view--down-arrow"
+        aria-hidden="true"
+      />
+      <span className="react-datepicker__sr-only">Month</span>
       <span className="react-datepicker__month-read-view--selected-month">
         {monthNames[this.props.month]}
       </span>

--- a/src/month_dropdown_options.tsx
+++ b/src/month_dropdown_options.tsx
@@ -10,7 +10,7 @@ interface MonthDropdownOptionsProps {
 }
 
 export default class MonthDropdownOptions extends Component<MonthDropdownOptionsProps> {
-  monthOptionButtonsRef: Record<number, HTMLDivElement | null> = {};
+  monthOptionButtonsRef: Record<number, HTMLLIElement | null> = {};
 
   isSelectedMonth = (i: number): boolean => this.props.month === i;
 
@@ -42,14 +42,14 @@ export default class MonthDropdownOptions extends Component<MonthDropdownOptions
 
     return this.props.monthNames.map<React.ReactElement>(
       (month: string, i: number): React.ReactElement => (
-        <div
+        <li
           ref={(el) => {
             this.monthOptionButtonsRef[i] = el;
             if (this.isSelectedMonth(i)) {
               el?.focus();
             }
           }}
-          role="button"
+          role="option"
           tabIndex={0}
           className={
             this.isSelectedMonth(i)
@@ -59,15 +59,20 @@ export default class MonthDropdownOptions extends Component<MonthDropdownOptions
           key={month}
           onClick={this.onChange.bind(this, i)}
           onKeyDown={this.handleOptionKeyDown.bind(this, i)}
-          aria-selected={this.isSelectedMonth(i) ? "true" : undefined}
+          aria-selected={this.isSelectedMonth(i)}
         >
           {this.isSelectedMonth(i) ? (
-            <span className="react-datepicker__month-option--selected">✓</span>
+            <span
+              className="react-datepicker__month-option--selected"
+              aria-hidden="true"
+            >
+              ✓
+            </span>
           ) : (
             ""
           )}
           {month}
-        </div>
+        </li>
       ),
     );
   };
@@ -82,7 +87,7 @@ export default class MonthDropdownOptions extends Component<MonthDropdownOptions
         className="react-datepicker__month-dropdown"
         onClickOutside={this.handleClickOutside}
       >
-        {this.renderOptions()}
+        <div role="listbox">{this.renderOptions()}</div>
       </ClickOutsideWrapper>
     );
   }

--- a/src/stylesheets/datepicker.scss
+++ b/src/stylesheets/datepicker.scss
@@ -222,6 +222,7 @@ h2.react-datepicker__current-month {
     display: block;
     margin-left: auto;
     margin-right: auto;
+    width: 100%;
 
     &-previous {
       top: 4px;
@@ -674,6 +675,12 @@ h2.react-datepicker__current-month {
     height: 150px;
     overflow-y: scroll;
   }
+}
+
+.react-datepicker__year-options-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
 }
 
 .react-datepicker__year-option,

--- a/src/test/month_dropdown_test.test.tsx
+++ b/src/test/month_dropdown_test.test.tsx
@@ -40,12 +40,100 @@ describe("MonthDropdown", () => {
   });
 
   describe("scroll mode", () => {
+    const selectedMonthIndex = 11;
+
     beforeEach(() => {
-      monthDropdown = getMonthDropdown();
+      monthDropdown = getMonthDropdown({
+        month: selectedMonthIndex,
+      });
+    });
+
+    it("sets proper ARIA on read view button and toggles aria-expanded", () => {
+      const monthReadView = safeQuerySelector(
+        monthDropdown,
+        ".react-datepicker__month-read-view",
+      );
+      expect(monthReadView.getAttribute("aria-haspopup")).toBe("listbox");
+      expect(monthReadView.getAttribute("aria-expanded")).toBe("false");
+
+      fireEvent.click(monthReadView);
+
+      const monthReadViewAfterOpen = safeQuerySelector(
+        monthDropdown,
+        ".react-datepicker__month-read-view",
+      );
+      expect(monthReadViewAfterOpen.getAttribute("aria-expanded")).toBe("true");
+    });
+
+    it("marks the down arrow as aria-hidden so it is excluded from the accessibility tree", () => {
+      const downArrow = safeQuerySelector(
+        monthDropdown,
+        ".react-datepicker__month-read-view--down-arrow",
+      );
+
+      expect(downArrow.getAttribute("aria-hidden")).toBe("true");
+      expect(downArrow.textContent).toBe("");
+    });
+
+    it("renders a sr-only Month label for screen readers inside the read view button", () => {
+      const monthReadView = safeQuerySelector(
+        monthDropdown,
+        ".react-datepicker__month-read-view",
+      );
+      const srOnlyLabel = safeQuerySelector(
+        monthReadView,
+        ".react-datepicker__sr-only",
+      );
+
+      expect(srOnlyLabel.textContent).toBe("Month");
+      expect(srOnlyLabel.classList.contains("react-datepicker__sr-only")).toBe(
+        true,
+      );
+      expect(srOnlyLabel.getAttribute("aria-hidden")).not.toBe("true");
+    });
+
+    it("applies aria-selected to the selected month option in scroll dropdown", () => {
+      const monthReadView = safeQuerySelector(
+        monthDropdown,
+        ".react-datepicker__month-read-view",
+      );
+      fireEvent.click(monthReadView);
+
+      const allMonthOptions = safeQuerySelectorAll(
+        monthDropdown,
+        ".react-datepicker__month-option",
+      );
+      allMonthOptions.forEach((option, idx) => {
+        expect(option.getAttribute("aria-selected")).toBe(
+          idx === selectedMonthIndex ? "true" : "false",
+        );
+      });
+    });
+
+    it("applies aria-hidden to the selected month option's check mark in scroll dropdown", () => {
+      const monthReadView = safeQuerySelector(
+        monthDropdown,
+        ".react-datepicker__month-read-view",
+      );
+      fireEvent.click(monthReadView);
+      const allMonthOptions = safeQuerySelectorAll(
+        monthDropdown,
+        ".react-datepicker__month-option",
+      );
+
+      const selectedMonthOption = allMonthOptions[selectedMonthIndex];
+      expect(selectedMonthOption).not.toBeNull();
+
+      const checkSpan = selectedMonthOption?.querySelector<HTMLSpanElement>(
+        "span.react-datepicker__month-option--selected",
+      );
+      expect(checkSpan).not.toBeNull();
+      expect(checkSpan?.getAttribute("aria-hidden")).toBe("true");
     });
 
     it("shows the selected month in the initial view", () => {
-      expect(monthDropdown?.textContent).toContain("December");
+      const expectedMonthName = getMonthInLocale(selectedMonthIndex);
+      expect(monthDropdown?.textContent).toContain(expectedMonthName);
     });
 
     it("opens a list when read view is clicked", () => {
@@ -102,9 +190,9 @@ describe("MonthDropdown", () => {
         expect(notSelectedMonth?.textContent).not.toContain("December");
       });
 
-      it("does not add aria-selected property to the selected month", () => {
+      it("should have aria-selected set to false", () => {
         const ariaSelected = notSelectedMonth?.getAttribute("aria-selected");
-        expect(ariaSelected).toBeNull();
+        expect(ariaSelected).toBe("false");
       });
     });
 

--- a/src/test/year_dropdown_options_test.test.tsx
+++ b/src/test/year_dropdown_options_test.test.tsx
@@ -1,10 +1,17 @@
 import { render, fireEvent } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
 import React from "react";
 
 import { addYears, getYear, newDate, subYears } from "../date_utils";
 import YearDropdownOptions from "../year_dropdown_options";
 
 import { safeQuerySelector, safeQuerySelectorAll } from "./test_utils";
+
+function getYearOptionTextContents(container: HTMLElement): string[] {
+  return Array.from(
+    container.querySelectorAll(".react-datepicker__year-option"),
+  ).map((node) => node.textContent ?? "");
+}
 
 describe("YearDropdownOptions", () => {
   let yearDropdown: HTMLElement, handleChangeResult: number;
@@ -57,64 +64,136 @@ describe("YearDropdownOptions", () => {
     expect(yearsListLength).toBe(11);
   });
 
-  it("increments the available years when the 'upcoming years' button is clicked", () => {
-    const navigationYearsUpcoming = safeQuerySelector(
-      yearDropdown,
-      ".react-datepicker__navigation--years-upcoming",
-    );
-    fireEvent.click(navigationYearsUpcoming);
+  describe("year navigation buttons", () => {
+    it("renders upcoming and previous year controls as buttons with accessible labels", () => {
+      const upcomingButton = safeQuerySelector<HTMLButtonElement>(
+        yearDropdown,
+        ".react-datepicker__navigation--years-upcoming",
+      );
+      const previousButton = safeQuerySelector<HTMLButtonElement>(
+        yearDropdown,
+        ".react-datepicker__navigation--years-previous",
+      );
 
-    const textContents = Array.from(
-      yearDropdown?.querySelectorAll(".react-datepicker__year-option") ?? [],
-    ).map((node) => node.textContent);
+      expect(upcomingButton.tagName).toBe("BUTTON");
+      expect(upcomingButton.getAttribute("aria-label")).toBe(
+        "Show later years",
+      );
+      expect(previousButton.tagName).toBe("BUTTON");
+      expect(previousButton.getAttribute("aria-label")).toBe(
+        "Show earlier years",
+      );
+    });
 
-    expect(textContents).toEqual(
-      expect.arrayContaining([
-        "",
-        "2021",
-        "2020",
-        "2019",
-        "2018",
-        "2017",
-        "2016",
-        "✓2015",
-        "2014",
-        "2013",
-        "2012",
-        "2011",
-        "",
-      ]),
-    );
-  });
+    it("increments the available years when the upcoming years button is clicked", () => {
+      const upcomingButton = safeQuerySelector<HTMLButtonElement>(
+        yearDropdown,
+        ".react-datepicker__navigation--years-upcoming",
+      );
+      fireEvent.click(upcomingButton);
 
-  it("decrements the available years when the 'previous years' button is clicked", () => {
-    const navigationYearsPrevious = safeQuerySelector(
-      yearDropdown,
-      ".react-datepicker__navigation--years-previous",
-    );
-    fireEvent.click(navigationYearsPrevious);
+      expect(getYearOptionTextContents(yearDropdown)).toEqual(
+        expect.arrayContaining([
+          "",
+          "2021",
+          "2020",
+          "2019",
+          "2018",
+          "2017",
+          "2016",
+          "✓2015",
+          "2014",
+          "2013",
+          "2012",
+          "2011",
+          "",
+        ]),
+      );
+    });
 
-    const textContents = Array.from(
-      yearDropdown?.querySelectorAll(".react-datepicker__year-option") ?? [],
-    ).map((node) => node.textContent);
+    it("decrements the available years when the previous years button is clicked", () => {
+      const previousButton = safeQuerySelector<HTMLButtonElement>(
+        yearDropdown,
+        ".react-datepicker__navigation--years-previous",
+      );
+      fireEvent.click(previousButton);
 
-    expect(textContents).toEqual(
-      expect.arrayContaining([
-        "",
-        "2019",
-        "2018",
-        "2017",
-        "2016",
-        "✓2015",
-        "2014",
-        "2013",
-        "2012",
-        "2011",
-        "2010",
-        "2009",
-        "",
-      ]),
-    );
+      expect(getYearOptionTextContents(yearDropdown)).toEqual(
+        expect.arrayContaining([
+          "",
+          "2019",
+          "2018",
+          "2017",
+          "2016",
+          "✓2015",
+          "2014",
+          "2013",
+          "2012",
+          "2011",
+          "2010",
+          "2009",
+          "",
+        ]),
+      );
+    });
+
+    it("increments the available years when Enter is pressed on the upcoming years button", async () => {
+      const user = userEvent.setup();
+      const upcomingButton = safeQuerySelector<HTMLButtonElement>(
+        yearDropdown,
+        ".react-datepicker__navigation--years-upcoming",
+      );
+
+      upcomingButton.focus();
+      await user.keyboard("{Enter}");
+
+      expect(getYearOptionTextContents(yearDropdown)).toEqual(
+        expect.arrayContaining([
+          "",
+          "2021",
+          "2020",
+          "2019",
+          "2018",
+          "2017",
+          "2016",
+          "✓2015",
+          "2014",
+          "2013",
+          "2012",
+          "2011",
+          "",
+        ]),
+      );
+    });
+
+    it("decrements the available years when Enter is pressed on the previous years button", async () => {
+      const user = userEvent.setup();
+      const previousButton = safeQuerySelector<HTMLButtonElement>(
+        yearDropdown,
+        ".react-datepicker__navigation--years-previous",
+      );
+
+      previousButton.focus();
+      await user.keyboard("{Enter}");
+
+      expect(getYearOptionTextContents(yearDropdown)).toEqual(
+        expect.arrayContaining([
+          "",
+          "2019",
+          "2018",
+          "2017",
+          "2016",
+          "✓2015",
+          "2014",
+          "2013",
+          "2012",
+          "2011",
+          "2010",
+          "2009",
+          "",
+        ]),
+      );
+    });
   });
 
   it("calls the supplied onChange function when a year is clicked", () => {

--- a/src/test/year_dropdown_test.test.tsx
+++ b/src/test/year_dropdown_test.test.tsx
@@ -34,8 +34,24 @@ describe("YearDropdown", () => {
   });
 
   describe("scroll mode", () => {
+    const selectedYear = 2015;
+
     beforeEach(function () {
-      yearDropdown = getYearDropdown();
+      yearDropdown = getYearDropdown({
+        year: selectedYear,
+      });
+    });
+
+    it("read view has correct ARIA attributes and toggles aria-expanded", () => {
+      const yearReadView = safeQuerySelector<HTMLButtonElement>(
+        yearDropdown,
+        ".react-datepicker__year-read-view",
+      );
+      expect(yearReadView.getAttribute("aria-haspopup")).toBe("listbox");
+      expect(yearReadView.getAttribute("aria-expanded")).toBe("false");
+
+      fireEvent.click(yearReadView);
+      expect(yearReadView.getAttribute("aria-expanded")).toBe("true");
     });
 
     it("shows the selected year in the initial view", () => {
@@ -47,6 +63,65 @@ describe("YearDropdown", () => {
         "react-datepicker__year-dropdown",
       );
       expect(optionsView).toHaveLength(0);
+    });
+
+    it("marks the down arrow as aria-hidden so it is excluded from the accessibility tree", () => {
+      const downArrow = safeQuerySelector(
+        yearDropdown,
+        ".react-datepicker__year-read-view--down-arrow",
+      );
+
+      expect(downArrow.getAttribute("aria-hidden")).toBe("true");
+      expect(downArrow.textContent).toBe("");
+    });
+
+    it("renders a sr-only Year label for screen readers inside the read view button", () => {
+      const yearReadView = safeQuerySelector(
+        yearDropdown,
+        ".react-datepicker__year-read-view",
+      );
+      const srOnlyLabel = safeQuerySelector(
+        yearReadView,
+        ".react-datepicker__sr-only",
+      );
+
+      expect(srOnlyLabel.textContent).toBe("Year");
+      expect(srOnlyLabel.classList.contains("react-datepicker__sr-only")).toBe(
+        true,
+      );
+      expect(srOnlyLabel.getAttribute("aria-hidden")).not.toBe("true");
+    });
+
+    it("applies aria-selected to the selected year option in scroll dropdown", () => {
+      const yearReadView = safeQuerySelector(
+        yearDropdown,
+        ".react-datepicker__year-read-view",
+      );
+      fireEvent.click(yearReadView);
+
+      const selectedYearOption = safeQuerySelector(
+        yearDropdown,
+        ".react-datepicker__year-option--selected_year",
+      );
+      expect(selectedYearOption.getAttribute("aria-selected")).toBe("true");
+    });
+
+    it("applies aria-hidden to the selected year option's check mark in scroll dropdown", () => {
+      const yearReadView = safeQuerySelector(
+        yearDropdown,
+        ".react-datepicker__year-read-view",
+      );
+      fireEvent.click(yearReadView);
+      const selectedYearOption = safeQuerySelector(
+        yearDropdown,
+        ".react-datepicker__year-option--selected_year",
+      );
+
+      const checkSpan = selectedYearOption?.querySelector<HTMLSpanElement>(
+        "span.react-datepicker__year-option--selected",
+      );
+      expect(checkSpan).not.toBeNull();
+      expect(checkSpan?.getAttribute("aria-hidden")).toBe("true");
     });
 
     it("opens a list when read view is clicked", () => {

--- a/src/year_dropdown.tsx
+++ b/src/year_dropdown.tsx
@@ -71,8 +71,14 @@ export default class YearDropdown extends Component<
       style={{ visibility: visible ? "visible" : "hidden" }}
       className="react-datepicker__year-read-view"
       onClick={this.toggleDropdown}
+      aria-expanded={this.state.dropdownVisible}
+      aria-haspopup="listbox"
     >
-      <span className="react-datepicker__year-read-view--down-arrow" />
+      <span
+        className="react-datepicker__year-read-view--down-arrow"
+        aria-hidden="true"
+      />
+      <span className="react-datepicker__sr-only">Year</span>
       <span className="react-datepicker__year-read-view--selected-year">
         {this.props.year}
       </span>

--- a/src/year_dropdown_options.tsx
+++ b/src/year_dropdown_options.tsx
@@ -88,7 +88,7 @@ export default class YearDropdownOptions extends Component<
   }
 
   dropdownRef: React.RefObject<HTMLDivElement | null>;
-  yearOptionButtonsRef: Record<number, HTMLDivElement | null> = {};
+  yearOptionButtonsRef: Record<number, HTMLLIElement | null> = {};
 
   handleOptionKeyDown = (year: number, e: React.KeyboardEvent): void => {
     switch (e.key) {
@@ -119,14 +119,14 @@ export default class YearDropdownOptions extends Component<
 
     const selectedYear = this.props.year;
     const options = this.state.yearsList.map((year) => (
-      <div
+      <li
         ref={(el) => {
           this.yearOptionButtonsRef[year] = el;
           if (year === selectedYear) {
             el?.focus();
           }
         }}
-        role="button"
+        role="option"
         tabIndex={0}
         className={
           selectedYear === year
@@ -136,15 +136,20 @@ export default class YearDropdownOptions extends Component<
         key={year}
         onClick={this.onChange.bind(this, year)}
         onKeyDown={this.handleOptionKeyDown.bind(this, year)}
-        aria-selected={selectedYear === year ? "true" : undefined}
+        aria-selected={selectedYear === year}
       >
         {selectedYear === year ? (
-          <span className="react-datepicker__year-option--selected">✓</span>
+          <span
+            className="react-datepicker__year-option--selected"
+            aria-hidden="true"
+          >
+            ✓
+          </span>
         ) : (
           ""
         )}
         {year}
-      </div>
+      </li>
     ));
 
     const minYear = this.props.minDate ? getYear(this.props.minDate) : null;
@@ -152,25 +157,29 @@ export default class YearDropdownOptions extends Component<
 
     if (!maxYear || !this.state.yearsList.find((year) => year === maxYear)) {
       options.unshift(
-        <div
-          className="react-datepicker__year-option"
-          key={"upcoming"}
-          onClick={this.incrementYears}
-        >
-          <a className="react-datepicker__navigation react-datepicker__navigation--years react-datepicker__navigation--years-upcoming" />
-        </div>,
+        <li className="react-datepicker__year-option" key={"upcoming"}>
+          <button
+            className="react-datepicker__navigation react-datepicker__navigation--years react-datepicker__navigation--years-upcoming"
+            onClick={this.incrementYears}
+            role="button"
+            aria-label="Show later years"
+            tabIndex={0}
+          />
+        </li>,
       );
     }
 
     if (!minYear || !this.state.yearsList.find((year) => year === minYear)) {
       options.push(
-        <div
-          className="react-datepicker__year-option"
-          key={"previous"}
-          onClick={this.decrementYears}
-        >
-          <a className="react-datepicker__navigation react-datepicker__navigation--years react-datepicker__navigation--years-previous" />
-        </div>,
+        <li className="react-datepicker__year-option" key={"previous"}>
+          <button
+            className="react-datepicker__navigation react-datepicker__navigation--years react-datepicker__navigation--years-previous"
+            onClick={this.decrementYears}
+            role="button"
+            aria-label="Show earlier years"
+            tabIndex={0}
+          />
+        </li>,
       );
     }
 
@@ -216,7 +225,9 @@ export default class YearDropdownOptions extends Component<
         containerRef={this.dropdownRef}
         onClickOutside={this.handleClickOutside}
       >
-        {this.renderOptions()}
+        <ul role="listbox" className="react-datepicker__year-options-list">
+          {this.renderOptions()}
+        </ul>
       </ClickOutsideWrapper>
     );
   }


### PR DESCRIPTION
## Description

This PR improves the accessibility of the month and year dropdowns in the date picker, covering both native select mode and custom dropdown (scroll) mode.

The changes ensure that both implementations provide correct semantics and a better experience for screen reader users, while keeping the existing API surface minimal.

## Background

This PR addresses the issue raised in:

Issue: https://github.com/Hacker0x01/react-datepicker/issues/6223

An earlier attempt was made in:

Previous PR: https://github.com/Hacker0x01/react-datepicker/pull/6232

This PR replaces the earlier one with an updated implementation that incorporates prior review feedback.

## Description
**Linked issue**: 6223

**Problem**
The current implementation of month and year dropdowns has few accessibility gaps:

- Native select dropdowns lack contextual labels, leading to ambiguous screen reader output (e.g., “June, combo box” without indicating it represents a month)
- Custom dropdown (`scroll` mode) does not fully follow listbox semantics
- Incorrect role usage (e.g., `role="button"` for selectable items) leads to inconsistent screen reader behavior
- Navigation controls (e.g., “Show earlier/later years”) rely on non-semantic elements and inconsistent labeling

These issues result in:
- Reduced clarity for screen reader users
- Inconsistent keyboard navigation
- Non-standard ARIA patterns

## **Changes**
1. Native select mode
- Added aria-label="Month" / aria-label="Year" to provide context (e.g., “Month, June, combo box”)
- Avoided adding <label> to prevent additional DOM complexity and ID management
- Did not introduce new props for ARIA labels to keep API surface minimal
2. Custom dropdown (scroll) mode
- Listbox semantics
- Ensured dropdown uses listbox pattern:
```
options → role="option"
selection → aria-selected
```
- Removed incorrect role="button" usage for selectable items
- Screen reader improvements
- Added visually hidden (`sr-only`) text where needed (e.g., “Month”) for consistent announcements
4. Year dropdown navigation (pagination)
- Replaced anchor elements (<a>) with semantic <button> elements
- Added accessible names using visually hidden text (instead of relying solely on aria-label) for better NVDA support

Interaction behavior
Navigation controls remain buttons (actions), not options.  They are:
- reachable via Tab
- not part of arrow key navigation (listbox behavior)

This aligns with ARIA practices, where only `role="option"` participates in arrow navigation.

## API Impact
- **No new props introduced** (e.g., `ariaMonthDropdownLabel`)
- Avoided expanding API for internal accessibility labels
If needed, support for custom `aria-labels` can be added in a future iteration.

## Testing
Tested with:
- NVDA
- Windows Narrator

## Contribution checklist
- [x] I have followed the [contributing guidelines](https://github.com/Hacker0x01/react-datepicker/blob/main/CONTRIBUTING.md).
- [x] I have added sufficient test coverage for my changes.
- [x] I have formatted my code with Prettier and checked for linting issues with ESLint for code readability.
