### PR TITLE
🐛 Fix: Respect minDate/maxDate in Month Dropdown (`showMonthDropdown`)

### DIFF
--- a/src/calendar.tsx
+++ b/src/calendar.tsx
@@ -127,7 +127,7 @@ type CalendarProps = React.PropsWithChildren<
     YearDropdownProps,
     "date" | "onChange" | "year" | "minDate" | "maxDate"
   > &
-    Omit<MonthDropdownProps, "month" | "onChange"> &
+    Omit<MonthDropdownProps, "month" | "onChange" | "date"> &
     Omit<MonthYearDropdownProps, "date" | "onChange" | "minDate" | "maxDate"> &
     Omit<
       YearProps,
@@ -875,6 +875,7 @@ export default class Calendar extends Component<CalendarProps, CalendarState> {
         {...Calendar.defaultProps}
         {...this.props}
         month={getMonth(this.state.date)}
+        date={this.state.date}
         onChange={this.changeMonth}
       />
     );

--- a/src/month_dropdown.tsx
+++ b/src/month_dropdown.tsx
@@ -3,6 +3,8 @@ import React, { Component } from "react";
 import {
   getMonthShortInLocale,
   getMonthInLocale,
+  isMonthDisabled,
+  setMonth,
   type Locale,
 } from "./date_utils";
 import MonthDropdownOptions from "./month_dropdown_options";
@@ -36,7 +38,11 @@ export default class MonthDropdown extends Component<
   renderSelectOptions = (monthNames: string[]): React.ReactElement[] =>
     monthNames.map<React.ReactElement>(
       (m: string, i: number): React.ReactElement => (
-        <option key={m} value={i}>
+        <option
+          key={m}
+          value={i}
+          disabled={isMonthDisabled(setMonth(this.props.date, i), this.props)}
+        >
           {m}
         </option>
       ),
@@ -91,7 +97,10 @@ export default class MonthDropdown extends Component<
 
   onChange = (month: number): void => {
     this.toggleDropdown();
-    if (month !== this.props.month) {
+    if (
+      month !== this.props.month &&
+      !isMonthDisabled(setMonth(this.props.date, month), this.props)
+    ) {
       this.props.onChange(month);
     }
   };

--- a/src/month_dropdown_options.tsx
+++ b/src/month_dropdown_options.tsx
@@ -1,18 +1,31 @@
+import { clsx } from "clsx";
 import React, { Component } from "react";
 
 import { ClickOutsideWrapper } from "./click_outside_wrapper";
+import {
+  isMonthDisabled,
+  setMonth,
+  type DateFilterOptions,
+} from "./date_utils";
 
-interface MonthDropdownOptionsProps {
+interface MonthDropdownOptionsProps extends Pick<
+  DateFilterOptions,
+  "minDate" | "maxDate" | "excludeDates" | "includeDates" | "filterDate"
+> {
   onCancel: VoidFunction;
   onChange: (month: number) => void;
   month: number;
   monthNames: string[];
+  date: Date;
 }
 
 export default class MonthDropdownOptions extends Component<MonthDropdownOptionsProps> {
   monthOptionButtonsRef: Record<number, HTMLDivElement | null> = {};
 
   isSelectedMonth = (i: number): boolean => this.props.month === i;
+
+  isDisabledMonth = (i: number): boolean =>
+    isMonthDisabled(setMonth(this.props.date, i), this.props);
 
   handleOptionKeyDown = (i: number, e: React.KeyboardEvent): void => {
     switch (e.key) {
@@ -41,38 +54,49 @@ export default class MonthDropdownOptions extends Component<MonthDropdownOptions
     this.monthOptionButtonsRef = {};
 
     return this.props.monthNames.map<React.ReactElement>(
-      (month: string, i: number): React.ReactElement => (
-        <div
-          ref={(el) => {
-            this.monthOptionButtonsRef[i] = el;
-            if (this.isSelectedMonth(i)) {
-              el?.focus();
-            }
-          }}
-          role="button"
-          tabIndex={0}
-          className={
-            this.isSelectedMonth(i)
-              ? "react-datepicker__month-option react-datepicker__month-option--selected_month"
-              : "react-datepicker__month-option"
-          }
-          key={month}
-          onClick={this.onChange.bind(this, i)}
-          onKeyDown={this.handleOptionKeyDown.bind(this, i)}
-          aria-selected={this.isSelectedMonth(i) ? "true" : undefined}
-        >
-          {this.isSelectedMonth(i) ? (
-            <span className="react-datepicker__month-option--selected">✓</span>
-          ) : (
-            ""
-          )}
-          {month}
-        </div>
-      ),
+      (month: string, i: number): React.ReactElement => {
+        const isDisabled = this.isDisabledMonth(i);
+        return (
+          <div
+            ref={(el) => {
+              this.monthOptionButtonsRef[i] = el;
+              if (this.isSelectedMonth(i)) {
+                el?.focus();
+              }
+            }}
+            role="button"
+            tabIndex={0}
+            className={clsx("react-datepicker__month-option", {
+              "react-datepicker__month-option--selected_month":
+                this.isSelectedMonth(i),
+              "react-datepicker__month-option--disabled": isDisabled,
+            })}
+            key={month}
+            onClick={this.onChange.bind(this, i)}
+            onKeyDown={this.handleOptionKeyDown.bind(this, i)}
+            aria-selected={this.isSelectedMonth(i) ? "true" : undefined}
+            aria-disabled={isDisabled ? "true" : undefined}
+          >
+            {this.isSelectedMonth(i) ? (
+              <span className="react-datepicker__month-option--selected">
+                ✓
+              </span>
+            ) : (
+              ""
+            )}
+            {month}
+          </div>
+        );
+      },
     );
   };
 
-  onChange = (month: number): void => this.props.onChange(month);
+  onChange = (month: number): void => {
+    if (this.isDisabledMonth(month)) {
+      return;
+    }
+    this.props.onChange(month);
+  };
 
   handleClickOutside = (): void => this.props.onCancel();
 

--- a/src/stylesheets/datepicker.scss
+++ b/src/stylesheets/datepicker.scss
@@ -723,6 +723,16 @@ h2.react-datepicker__current-month {
   }
 }
 
+.react-datepicker__month-option--disabled {
+  cursor: default;
+  color: $datepicker__muted-color;
+
+  &:hover {
+    cursor: default;
+    background-color: transparent;
+  }
+}
+
 .react-datepicker__close-icon {
   cursor: pointer;
   background-color: transparent;

--- a/src/test/month_dropdown_test.test.tsx
+++ b/src/test/month_dropdown_test.test.tsx
@@ -21,14 +21,15 @@ describe("MonthDropdown", () => {
 
   function getMonthDropdown(
     overrideProps?: Partial<
-      Pick<MonthDropdownProps, "dropdownMode" | "month" | "onChange">
+      Pick<MonthDropdownProps, "dropdownMode" | "month" | "onChange" | "date">
     > &
-      Omit<MonthDropdownProps, "dropdownMode" | "month" | "onChange">,
+      Omit<MonthDropdownProps, "dropdownMode" | "month" | "onChange" | "date">,
   ) {
     return render(
       <MonthDropdown
         dropdownMode="scroll"
         month={11}
+        date={new Date(2025, 11, 1)}
         onChange={mockHandleChange}
         {...overrideProps}
       />,
@@ -138,6 +139,7 @@ describe("MonthDropdown", () => {
           onChange={onCancelSpy}
           month={11}
           monthNames={monthNames}
+          date={new Date(2025, 11, 1)}
         />,
       );
       fireEvent.mouseDown(document.body);
@@ -291,6 +293,58 @@ describe("MonthDropdown", () => {
       const firstMonthOption = monthOptions[0];
       expect(document.activeElement).toEqual(firstMonthOption);
     });
+
+    it("does not call onChange when clicking a month outside of minDate/maxDate range", () => {
+      monthDropdown = getMonthDropdown({
+        month: 3,
+        date: new Date(2025, 3, 1),
+        minDate: new Date(2025, 0, 1),
+        maxDate: new Date(2025, 5, 30),
+      });
+      const monthReadView = safeQuerySelector(
+        monthDropdown,
+        ".react-datepicker__month-read-view",
+      );
+      fireEvent.click(monthReadView);
+
+      const monthOptions = safeQuerySelectorAll(
+        monthDropdown,
+        ".react-datepicker__month-option",
+      );
+
+      // August (index 7) is outside the Jan-Jun 2025 range
+      const disabledMonthOption = monthOptions[7]!;
+      expect(disabledMonthOption.getAttribute("aria-disabled")).toEqual("true");
+
+      fireEvent.click(disabledMonthOption);
+      expect(handleChangeResult).toBeNull();
+    });
+
+    it("calls onChange when clicking a month inside of minDate/maxDate range", () => {
+      monthDropdown = getMonthDropdown({
+        month: 3,
+        date: new Date(2025, 3, 1),
+        minDate: new Date(2025, 0, 1),
+        maxDate: new Date(2025, 5, 30),
+      });
+      const monthReadView = safeQuerySelector(
+        monthDropdown,
+        ".react-datepicker__month-read-view",
+      );
+      fireEvent.click(monthReadView);
+
+      const monthOptions = safeQuerySelectorAll(
+        monthDropdown,
+        ".react-datepicker__month-option",
+      );
+
+      // May (index 4) is inside the Jan-Jun 2025 range
+      const enabledMonthOption = monthOptions[4]!;
+      expect(enabledMonthOption.getAttribute("aria-disabled")).toBeNull();
+
+      fireEvent.click(enabledMonthOption);
+      expect(handleChangeResult).toEqual(4);
+    });
   });
 
   describe("select mode", () => {
@@ -380,6 +434,33 @@ describe("MonthDropdown", () => {
         target: { value: 9 },
       });
       expect(handleChangeResult).toEqual(9);
+    });
+
+    it("disables options for months outside of minDate/maxDate range", () => {
+      monthDropdown = getMonthDropdown({
+        dropdownMode: "select",
+        month: 3,
+        date: new Date(2025, 3, 1),
+        minDate: new Date(2025, 0, 1),
+        maxDate: new Date(2025, 5, 30),
+      });
+      const options = Array.from(
+        monthDropdown.querySelectorAll<HTMLOptionElement>("option"),
+      );
+      expect(options.map((o) => o.disabled)).toEqual([
+        false, // Jan
+        false, // Feb
+        false, // Mar
+        false, // Apr
+        false, // May
+        false, // Jun
+        true, // Jul
+        true, // Aug
+        true, // Sep
+        true, // Oct
+        true, // Nov
+        true, // Dec
+      ]);
     });
   });
 });


### PR DESCRIPTION
## Description

Linked issue: #6286 

### Problem

`showMonthDropdown` ignored `minDate`, `maxDate`, `excludeDates`, `includeDates`, and `filterDate`, allowing navigation to any month of the year even when the date range restricted it. For example, with `minDate=2025-01-01` and `maxDate=2025-06-30`, users could still pick July–December 2025 via the month dropdown.

`showMonthYearDropdown` already handled this correctly, because `MonthYearDropdown` builds its option list directly from the `minDate`–`maxDate` range. `MonthDropdown` is a separate, independent component that always rendered all 12 months and called `onChange` unconditionally — it never consulted `minDate`/`maxDate` at all.

## Fix

Reused the existing `isMonthDisabled` helper (already used by the full month-grid picker in `month.tsx` for the identical constraint) to disable out-of-range months in both dropdown modes:

- **`month_dropdown_options.tsx`** (scroll mode) — each month option is checked against `minDate`/`maxDate`/`excludeDates`/`includeDates`/`filterDate`. Disabled options get an `--disabled` class + `aria-disabled`, and clicks/Enter on them are ignored.
- **`month_dropdown.tsx`** (select mode) — the corresponding `<option>` elements get the native `disabled` attribute; `onChange` also guards against disabled months.
- **`calendar.tsx`** — passes the currently viewed `date` into `MonthDropdown` so it has year context (needed because `MonthDropdown` only tracks a bare month index 0–11, not a year).
- **`datepicker.scss`** — added a muted/`cursor: default` style for `.react-datepicker__month-option--disabled`, matching the existing disabled-day styling.

## Why gray out instead of filter out?

`YearDropdown` and `MonthYearDropdown` filter their option lists because each option is a *self-contained* unit (a year, or a year+month pair) — whether it's in range depends only on `minDate`/`maxDate`.

`MonthDropdown` is different: its 12 options ("January"–"December") only make sense relative to whichever year is *currently displayed*, and that year is controlled externally (the sibling `YearDropdown`, or prev/next navigation) — `MonthDropdown` has no say in it. If we filtered instead of disabled, the list's length and item positions would change every time the user changed the year. For example, with `minDate=Jun 2024` and `maxDate=Mar 2026`: viewing 2024 would show 6 months, viewing 2025 would show all 12, and viewing 2026 would show 3 — a jarring, unstable list for what's meant to be a fixed 12-month picker.

This is exactly the same constraint the full month-grid picker (`month.tsx`, used by `showFullMonthYearPicker`) already faces, and it solves it by disabling rather than filtering (`isMonthDisabled` / `month-text--disabled`). Graying out keeps the option list stable and consistent with that existing precedent, and is also more accessible — `aria-disabled` tells assistive tech the option exists but isn't currently selectable, rather than having it silently disappear.


## Contribution checklist
- [x] I have followed the [contributing guidelines](https://github.com/Hacker0x01/react-datepicker/blob/main/CONTRIBUTING.md).
- [x] I have added sufficient test coverage for my changes.
- [x] I have formatted my code with Prettier and checked for linting issues with ESLint for code readability.
