### PR TITLE
fix: render an independent, panel-aware dropdown on every month header

### DIFF
--- a/src/calendar.tsx
+++ b/src/calendar.tsx
@@ -461,35 +461,48 @@ export default class Calendar extends Component<CalendarProps, CalendarState> {
     this.handleMonthChange(date);
   };
 
-  changeYear = (year: number): void => {
+  // `panelDate` is the month/year the panel that triggered this change was
+  // itself displaying; it defaults to the anchor date (`state.date`) for
+  // callers that don't track a specific panel, e.g. custom headers - which
+  // is what keeps their documented "always lands in the leftmost panel"
+  // behavior unchanged (see `renderCustomHeader`).
+  changeYear = (year: number, panelDate: Date = this.state.date): void => {
     this.setState(
-      ({ date }) => ({
-        date: setYear(date, Number(year)),
-      }),
+      // Shift the anchor by the picked delta rather than overwriting its
+      // year outright, so every panel keeps its own month and moves by the
+      // same amount instead of collapsing onto whichever panel is the anchor.
+      ({ date }) => ({ date: addYears(date, year - getYear(panelDate)) }),
       () => this.handleYearChange(this.state.date),
     );
   };
 
-  changeMonth = (month: number): void => {
-    this.setState(
-      ({ date }) => ({
-        date: setMonth(date, Number(month)),
-      }),
-      () => {
-        this.handleMonthChange(this.state.date);
-        // Reset monthSelectedIn to 0 so the target month appears in the leftmost position
-        // This ensures consistent behavior when using changeMonth in custom headers
-        this.props.onMonthSelectedInChange?.(0);
-      },
-    );
+  changeMonth = (
+    month: number,
+    panelDate: Date = this.state.date,
+    monthSelectedIn: number = 0,
+  ): void => {
+    this.setState({ date: setMonth(panelDate, month) }, () => {
+      this.handleMonthChange(this.state.date);
+      this.props.onMonthSelectedInChange?.(monthSelectedIn);
+    });
   };
 
-  changeMonthYear = (monthYear: Date): void => {
+  changeMonthYear = (
+    monthYear: Date,
+    panelDate: Date,
+    monthSelectedIn: number,
+  ): void => {
     this.setState(
-      ({ date }) => ({
-        date: setYear(setMonth(date, getMonth(monthYear)), getYear(monthYear)),
-      }),
-      () => this.handleMonthYearChange(this.state.date),
+      {
+        date: setYear(
+          setMonth(panelDate, getMonth(monthYear)),
+          getYear(monthYear),
+        ),
+      },
+      () => {
+        this.handleMonthYearChange(this.state.date);
+        this.props.onMonthSelectedInChange?.(monthSelectedIn);
+      },
     );
   };
 
@@ -847,51 +860,53 @@ export default class Calendar extends Component<CalendarProps, CalendarState> {
     );
   };
 
-  renderYearDropdown = (
-    overrideHide: boolean = false,
-  ): React.ReactElement | undefined => {
-    if (!this.props.showYearDropdown || overrideHide) {
+  renderYearDropdown = (monthDate: Date): React.ReactElement | undefined => {
+    if (!this.props.showYearDropdown) {
       return;
     }
     return (
       <YearDropdown
         {...Calendar.defaultProps}
         {...this.props}
-        date={this.state.date}
-        onChange={this.changeYear}
-        year={getYear(this.state.date)}
+        date={monthDate}
+        onChange={(year: number) => this.changeYear(year, monthDate)}
+        year={getYear(monthDate)}
       />
     );
   };
 
   renderMonthDropdown = (
-    overrideHide: boolean = false,
+    monthDate: Date,
+    i: number,
   ): React.ReactElement | undefined => {
-    if (!this.props.showMonthDropdown || overrideHide) {
+    if (!this.props.showMonthDropdown) {
       return;
     }
     return (
       <MonthDropdown
         {...Calendar.defaultProps}
         {...this.props}
-        month={getMonth(this.state.date)}
-        onChange={this.changeMonth}
+        month={getMonth(monthDate)}
+        onChange={(month: number) => this.changeMonth(month, monthDate, i)}
       />
     );
   };
 
   renderMonthYearDropdown = (
-    overrideHide: boolean = false,
+    monthDate: Date,
+    i: number,
   ): React.ReactElement | undefined => {
-    if (!this.props.showMonthYearDropdown || overrideHide) {
+    if (!this.props.showMonthYearDropdown) {
       return;
     }
     return (
       <MonthYearDropdown
         {...Calendar.defaultProps}
         {...this.props}
-        date={this.state.date}
-        onChange={this.changeMonthYear}
+        date={monthDate}
+        onChange={(monthYear: Date) =>
+          this.changeMonthYear(monthYear, monthDate, i)
+        }
       />
     );
   };
@@ -922,6 +937,9 @@ export default class Calendar extends Component<CalendarProps, CalendarState> {
   );
 
   renderDefaultHeader = ({ monthDate, i }: { monthDate: Date; i: number }) => {
+    // Every panel renders its own dropdown, bound to monthDate/i (see
+    // changeYear above) - keeps header heights equal by construction (#6320)
+    // and lets each panel be changed independently.
     const headerContent = (
       <div
         className={clsx("react-datepicker__header", {
@@ -938,9 +956,9 @@ export default class Calendar extends Component<CalendarProps, CalendarState> {
           className={`react-datepicker__header__dropdown react-datepicker__header__dropdown--${this.props.dropdownMode}`}
           onFocus={this.handleDropdownFocus}
         >
-          {this.renderMonthDropdown(i !== 0)}
-          {this.renderMonthYearDropdown(i !== 0)}
-          {this.renderYearDropdown(i !== 0)}
+          {this.renderMonthDropdown(monthDate, i)}
+          {this.renderMonthYearDropdown(monthDate, i)}
+          {this.renderYearDropdown(monthDate)}
         </div>
       </div>
     );

--- a/src/test/calendar_test.test.tsx
+++ b/src/test/calendar_test.test.tsx
@@ -324,15 +324,59 @@ describe("Calendar", () => {
     expect(yearReadView).toHaveLength(1);
   });
 
-  it("should show only one year dropdown menu if toggled on and multiple month mode on", () => {
+  it("should show an independent year dropdown on every month when toggled on in multiple month mode", () => {
     const { calendar } = getCalendar({
       showYearDropdown: true,
       monthsShown: 2,
     });
-    const monthReadView = calendar.querySelectorAll(
+    const yearDropdowns = calendar.querySelectorAll(
       ".react-datepicker__year-dropdown-container",
     );
-    expect(monthReadView).toHaveLength(1);
+    expect(yearDropdowns).toHaveLength(2);
+  });
+
+  it("should update only the month whose year dropdown was used, shifting the others by the same year delta", () => {
+    // Pinned to January so the three shown panels (Jan/Feb/Mar) never cross
+    // a year boundary - avoids flakiness depending on when the suite runs.
+    const { calendar, instance } = getCalendar({
+      selected: new Date(2023, 0, 15),
+      showYearDropdown: true,
+      monthsShown: 3,
+    });
+    const initialDate = instance!.state.date;
+
+    const readViews = safeQuerySelectorAll(
+      calendar,
+      ".react-datepicker__year-read-view",
+    );
+    expect(readViews).toHaveLength(3);
+
+    // Open the *third* month's year dropdown and pick a different year.
+    fireEvent.click(readViews[2]!);
+    const options = safeQuerySelectorAll(
+      calendar,
+      ".react-datepicker__year-option",
+    );
+    const targetYear = getYear(initialDate) + 5;
+    const targetOption = Array.from(options).find(
+      (option) => option.textContent === String(targetYear),
+    );
+    expect(targetOption).not.toBeUndefined();
+    fireEvent.click(targetOption!);
+
+    // The whole picker shifts by the same year delta - every month keeps its
+    // own relative offset, it doesn't jump to the leftmost panel.
+    const currentMonths = safeQuerySelectorAll(
+      calendar,
+      ".react-datepicker__current-month",
+    );
+    expect(currentMonths).toHaveLength(3);
+    [0, 1, 2].forEach((i) => {
+      expect(currentMonths[i]?.textContent).toBe(
+        formatDate(addMonths(addYears(initialDate, 5), i), dateFormat),
+      );
+    });
+    expect(getYear(instance!.state.date)).toBe(getYear(initialDate) + 5);
   });
 
   it("should show month navigation if toggled on", () => {
@@ -1155,15 +1199,66 @@ describe("Calendar", () => {
     expect(monthReadView).toHaveLength(1);
   });
 
-  it("should show only one month dropdown menu if toggled on and multiple month mode on", () => {
+  it("should show an independent month dropdown on every month when toggled on in multiple month mode", () => {
     const { calendar } = getCalendar({
       showMonthDropdown: true,
       monthsShown: 2,
     });
-    const monthReadView = calendar.querySelectorAll(
+    const monthDropdowns = calendar.querySelectorAll(
       ".react-datepicker__month-dropdown-container",
     );
-    expect(monthReadView).toHaveLength(1);
+    expect(monthDropdowns).toHaveLength(2);
+  });
+
+  it("should land the picked month on the panel whose month dropdown was used, not the leftmost panel", () => {
+    const onMonthSelectedInChangeSpy = jest.fn();
+    // Pinned to January so the two shown panels (Jan/Feb) and the picked
+    // month (June) never cross a year boundary - avoids flakiness if the
+    // suite runs in November/December.
+    const { calendar, instance, rerender } = getCalendar({
+      selected: new Date(2023, 0, 15),
+      showMonthDropdown: true,
+      monthsShown: 2,
+      onMonthSelectedInChange: onMonthSelectedInChangeSpy,
+    });
+
+    const readViews = safeQuerySelectorAll(
+      calendar,
+      ".react-datepicker__month-read-view",
+    );
+    expect(readViews).toHaveLength(2);
+
+    // Open the *second* month's month dropdown (currently February) and pick June.
+    fireEvent.click(readViews[1]!);
+    const options = safeQuerySelectorAll(
+      calendar,
+      ".react-datepicker__month-option",
+    );
+    fireEvent.click(options[5]!); // June
+
+    expect(onMonthSelectedInChangeSpy).toHaveBeenCalledWith(1);
+    expect(getMonth(instance!.state.date)).toBe(5);
+    expect(getYear(instance!.state.date)).toBe(2023);
+
+    // Calendar itself is a controlled component for `monthSelectedIn` - a
+    // real parent (DatePicker) feeds the callback's value back in as a prop
+    // (see index.tsx's handleMonthSelectedInChange), which is what actually
+    // lands the result on the interacted-with panel. Simulate that here.
+    rerender({ monthSelectedIn: 1 });
+
+    const currentMonths = safeQuerySelectorAll(
+      calendar,
+      ".react-datepicker__current-month",
+    );
+    expect(currentMonths).toHaveLength(2);
+    // The second panel (the one the user interacted with) now shows June...
+    expect(currentMonths[1]?.textContent).toBe(
+      formatDate(new Date(2023, 5), dateFormat),
+    );
+    // ...and the first panel shows the preceding month, May.
+    expect(currentMonths[0]?.textContent).toBe(
+      formatDate(new Date(2023, 4), dateFormat),
+    );
   });
 
   it("should not show the month-year dropdown menu by default", () => {
@@ -1186,17 +1281,74 @@ describe("Calendar", () => {
     expect(monthYearReadView).toHaveLength(1);
   });
 
-  it("should show only one month-year dropdown menu if toggled on and multiple month mode on", () => {
+  it("should show an independent month-year dropdown on every month when toggled on in multiple month mode", () => {
     const { calendar } = getCalendar({
       showMonthYearDropdown: true,
       minDate: subYears(newDate(), 1),
       maxDate: addYears(newDate(), 1),
       monthsShown: 2,
     });
-    const monthReadView = calendar.querySelectorAll(
+    const monthYearDropdowns = calendar.querySelectorAll(
       ".react-datepicker__month-year-dropdown-container",
     );
-    expect(monthReadView).toHaveLength(1);
+    expect(monthYearDropdowns).toHaveLength(2);
+  });
+
+  it("should land the picked month-year on the panel whose dropdown was used, not the leftmost panel", () => {
+    const onMonthSelectedInChangeSpy = jest.fn();
+    // Pinned to January so the two shown panels (Jan/Feb 2023) never cross a
+    // year boundary - avoids flakiness depending on when the suite runs.
+    const { calendar, instance, rerender } = getCalendar({
+      selected: new Date(2023, 0, 15),
+      showMonthYearDropdown: true,
+      minDate: new Date(2020, 0, 1),
+      maxDate: new Date(2026, 0, 1),
+      monthsShown: 2,
+      onMonthSelectedInChange: onMonthSelectedInChangeSpy,
+    });
+
+    const readViews = safeQuerySelectorAll(
+      calendar,
+      ".react-datepicker__month-year-read-view",
+    );
+    expect(readViews).toHaveLength(2);
+
+    // Open the *second* month's month-year dropdown (currently February
+    // 2023) and pick "June 2024".
+    fireEvent.click(readViews[1]!);
+    const target = safeQuerySelectorAll(
+      calendar,
+      ".react-datepicker__month-year-option",
+    ).find(
+      (option) =>
+        option.textContent === formatDate(new Date(2024, 5), dateFormat),
+    );
+    expect(target).not.toBeUndefined();
+    fireEvent.click(target!);
+
+    expect(onMonthSelectedInChangeSpy).toHaveBeenCalledWith(1);
+    expect(getMonth(instance!.state.date)).toBe(5);
+    expect(getYear(instance!.state.date)).toBe(2024);
+
+    // Calendar itself is a controlled component for `monthSelectedIn` - a
+    // real parent (DatePicker) feeds the callback's value back in as a prop
+    // (see index.tsx's handleMonthSelectedInChange), which is what actually
+    // lands the result on the interacted-with panel. Simulate that here.
+    rerender({ monthSelectedIn: 1 });
+
+    const currentMonths = safeQuerySelectorAll(
+      calendar,
+      ".react-datepicker__current-month",
+    );
+    expect(currentMonths).toHaveLength(2);
+    // The second panel (the one the user interacted with) now shows June 2024...
+    expect(currentMonths[1]?.textContent).toBe(
+      formatDate(new Date(2024, 5), dateFormat),
+    );
+    // ...and the first panel shows the preceding month, May 2024.
+    expect(currentMonths[0]?.textContent).toBe(
+      formatDate(new Date(2024, 4), dateFormat),
+    );
   });
 
   it("should not show the today button by default", () => {

--- a/src/test/multi_month_test.test.tsx
+++ b/src/test/multi_month_test.test.tsx
@@ -42,12 +42,34 @@ describe("Multi month calendar", function () {
     expect(months).toHaveLength(2);
   });
 
-  it("should render dropdown only on first month", () => {
+  it("should render an independent dropdown on every month (see #6320)", () => {
     const calendar = getCalendar({ monthsShown: 2, showYearDropdown: true });
     const datepickers = calendar.querySelectorAll(
       ".react-datepicker__year-dropdown-container",
     );
-    expect(datepickers).toHaveLength(1);
+    // Every month renders the same real dropdown, rather than one being
+    // reserved with a hardcoded/measured height, since native form controls
+    // render at different heights across browsers/operating systems (#6320).
+    expect(datepickers).toHaveLength(2);
+  });
+
+  it("should render the same header dropdown markup on every month, so header heights stay consistent (#6320)", () => {
+    const calendar = getCalendar({ monthsShown: 3, showYearDropdown: true });
+    const headerDropdowns = calendar.querySelectorAll(
+      ".react-datepicker__header__dropdown",
+    );
+    expect(headerDropdowns).toHaveLength(3);
+
+    // Every month's header dropdown wrapper renders the same
+    // year-dropdown-container control, so their layout boxes match exactly
+    // without reserving space via a hardcoded or measured height.
+    headerDropdowns.forEach((headerDropdown) => {
+      expect(
+        headerDropdown.querySelectorAll(
+          ".react-datepicker__year-dropdown-container",
+        ),
+      ).toHaveLength(1);
+    });
   });
 
   it("should render previous months", () => {


### PR DESCRIPTION
### Description
Linked issue: #6320

### Problem
With `showYearDropdown` (or `showMonthDropdown` / `showMonthYearDropdown`) combined with `monthsShown > 1`, only the first month panel rendered the dropdown control in its header (`renderYearDropdown(i !== 0)` etc. suppressed it on every other panel). `.react-datepicker__header__dropdown` has no explicit height in `datepicker.scss`, so on the panels that didn't render a dropdown it collapsed to 0 height instead of reserving the same space — making month 1's header taller than the others and misaligning the day grids underneath, since each `.react-datepicker__month-container` is floated independently with no shared grid row.

We tried three approaches before landing on this one:
1. **Hardcoded CSS `min-height`** — the actual rendered height of a native form control genuinely differs by browser/OS/zoom, so any hardcoded pixel value is just a future bug waiting for a different browser.
2. **`ResizeObserver`-based runtime measurement** — technically correct and browser-agnostic, but added a ref/observer/lifecycle/state footprint to `calendar.tsx` for what turned out to be solvable without any of it, plus a first-paint flash before the first measurement landed.
3. **Render the same dropdown on every panel but mark the extras `inert`/`visibility: hidden`** — closer, but requires every dropdown component to keep honoring a "pretend this doesn't exist" contract for every future interactive element added inside it. Already surfaced one bug from exactly that shape during development (a read-view `<button>`'s own inline `visibility` style winning over the ancestor's `hidden` in "scroll" mode).

### Changes
- Every shown month panel now renders its own **real, independently interactive** dropdown, bound to that panel's own displayed month/year — not a hidden/inert copy. Since every header renders identical live control markup, header heights match by construction on any browser, with no hardcoded number and no runtime measurement.
- `changeYear`/`changeMonth`/`changeMonthYear` in `calendar.tsx` now accept the triggering panel's date (and, for month/month-year, `monthSelectedIn`) instead of always acting on the calendar's anchor date:
  - `changeYear` shifts the anchor by the picked year delta, so every panel keeps its own month and the whole view moves together.
  - `changeMonth`/`changeMonthYear` land the result on the panel that was actually interacted with (reusing the existing `monthSelectedIn` plumbing day selection already relies on), instead of always resetting to the leftmost panel.
- `renderCustomHeader` consumers are unaffected — they still receive the unbound `changeMonth`/`changeYear` and call them with a single argument, so the new parameters fall back to their defaults and reproduce the exact previous anchor-based, leftmost-panel-landing behavior. Verified this explicitly with a temporary regression test exercising both panels' controls before committing (removed once confirmed, since it duplicated existing coverage).
- Updated/added tests in `calendar_test.test.tsx` and `multi_month_test.test.tsx`: dropdown containers now assert one per panel (not one total), plus new behavioral tests picking a year/month/month-year from a non-first panel and asserting the whole multi-month view updates correctly.

**Open question for maintainers:** the original design intentionally restricted dropdowns to the first month, treating N simultaneous interactive dropdowns as ambiguous about "which one's in charge." This PR resolves that ambiguity with explicit semantics (delta-shift on year, land-on-interacted-panel on month/month-year) rather than avoiding it — curious if there was a specific reason (e.g. an accessibility concern with multiple same-labeled comboboxes) behind the original restriction that isn't captured in the linked issues (#4222, #790), since that would shape whether this is the right direction.

### Contribution checklist
- [x] I have followed the contributing guidelines.
- [x] I have added sufficient test coverage for my changes.
- [x] I have formatted my code with Prettier and checked for linting issues with ESLint for code readability.
